### PR TITLE
Onboarding: add tflint and backend example

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -25,3 +25,7 @@ jobs:
           else
             echo "No validate script found"; exit 0
           fi
+      - name: Run tflint (optional)
+        uses: terraform-linters/tflint-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,6 @@
+plugin "aws" {}
+
+# Basic tflint config — extend per repo IaC needs
+rule "aws_instance_invalid_type" {
+  enabled = true
+}

--- a/infra/backend.tf.example
+++ b/infra/backend.tf.example
@@ -1,0 +1,17 @@
+/*
+Example Terraform backend configuration (GCS) — replace placeholders.
+
+Store this file as `backend.tf` (not committed with real keys) and configure
+the `bucket`, `prefix`, and `kms_key_name` for CMEK per your org settings.
+
+*/
+
+terraform {
+  backend "gcs" {
+    bucket      = "<YOUR_TERRAFORM_STATE_BUCKET>"
+    prefix      = "<project>/<env>"
+    credentials = "<PATH_TO_SERVICE_ACCOUNT_JSON>" # use CI service account instead
+    # To use CMEK-managed keys, set the KMS key name:
+    # kms_key_name = "projects/<project>/locations/<location>/keyRings/<ring>/cryptoKeys/<key>"
+  }
+}


### PR DESCRIPTION
Adds .tflint.hcl, infra/backend.tf.example, and CI step to run tflint. See .github/ISSUES for tracking.