### PR TITLE
fix(ci): fail-closed security + validate-config enforcement (P1 #307)

### DIFF
--- a/.github/workflows/issue-duplicate-sentry.yml
+++ b/.github/workflows/issue-duplicate-sentry.yml
@@ -82,13 +82,15 @@ jobs:
               .map((c) => `- #${c.number} ${c.title}`)
               .join('\n');
 
-            const body = `${marker}
-Potential duplicate or related open issues detected for triage:
-
-${list}
-
-Please choose one canonical issue and close superseded duplicates with a cross-link.
-If this issue is distinct, add a short comment explaining why.`;
+            const body = [
+              marker,
+              'Potential duplicate or related open issues detected for triage:',
+              '',
+              list,
+              '',
+              'Please choose one canonical issue and close superseded duplicates with a cross-link.',
+              'If this issue is distinct, add a short comment explaining why.',
+            ].join('\n');
 
             await github.rest.issues.createComment({
               owner,

--- a/.github/workflows/issue-duplicate-sentry.yml
+++ b/.github/workflows/issue-duplicate-sentry.yml
@@ -1,0 +1,100 @@
+name: Issue Duplicate Sentry
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  suggest-duplicates:
+    name: Suggest potential duplicate issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Suggest likely duplicate threads
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue || issue.pull_request) {
+              core.info('Not a standard issue; skipping.');
+              return;
+            }
+
+            const title = (issue.title || '').trim();
+            if (!title) {
+              core.info('Empty issue title; skipping.');
+              return;
+            }
+
+            // Build a focused query from meaningful words to reduce false positives.
+            const words = title
+              .toLowerCase()
+              .replace(/[^a-z0-9\s-]/g, ' ')
+              .split(/\s+/)
+              .filter((w) => w.length >= 4)
+              .slice(0, 6);
+
+            if (words.length === 0) {
+              core.info('No meaningful title keywords; skipping.');
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const query = `repo:${owner}/${repo} is:issue is:open -is:pull-request ${words.join(' ')}`;
+
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: query,
+              per_page: 20,
+            });
+
+            const currentNumber = issue.number;
+            const candidates = search.data.items
+              .filter((i) => i.number !== currentNumber)
+              .slice(0, 5);
+
+            if (candidates.length === 0) {
+              core.info('No likely duplicates found.');
+              return;
+            }
+
+            const marker = '<!-- duplicate-sentry -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: currentNumber,
+              per_page: 100,
+            });
+
+            const alreadyCommented = comments.some((c) =>
+              c.user?.login === 'github-actions[bot]' && typeof c.body === 'string' && c.body.includes(marker)
+            );
+
+            if (alreadyCommented && context.payload.action !== 'opened') {
+              core.info('Duplicate sentry comment already exists; skipping repeat comment.');
+              return;
+            }
+
+            const list = candidates
+              .map((c) => `- #${c.number} ${c.title}`)
+              .join('\n');
+
+            const body = `${marker}
+Potential duplicate or related open issues detected for triage:
+
+${list}
+
+Please choose one canonical issue and close superseded duplicates with a cross-link.
+If this issue is distinct, add a short comment explaining why.`;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: currentNumber,
+              body,
+            });
+
+            core.info(`Posted duplicate suggestion with ${candidates.length} candidate(s).`);

--- a/.github/workflows/issue-duplicate-sentry.yml
+++ b/.github/workflows/issue-duplicate-sentry.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Suggest likely duplicate threads
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,6 @@ jobs:
   trufflehog:
     name: TruffleHog secrets scan (fail-closed)
     runs-on: ubuntu-latest
-    continue-on-error: true  # Non-blocking for PR evaluation
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -40,7 +39,6 @@ jobs:
   gitleaks:
     name: Gitleaks secrets scan (fail-closed)
     runs-on: ubuntu-latest
-    continue-on-error: true  # Non-blocking for PR evaluation
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -63,29 +61,26 @@ jobs:
   checkov:
     name: Checkov IaC scan (fail on HIGH/CRITICAL)
     runs-on: ubuntu-latest
-    continue-on-error: true  # Make non-blocking while working through IaC issues
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install Checkov
         run: pip install --upgrade checkov
 
       - name: Run Checkov
         run: |
-          # Advisory mode while policy baseline is stabilized; use supported flags only.
+          # Fail closed for high/critical findings.
           checkov -d terraform \
             --framework terraform \
             --quiet \
-            --soft-fail \
-            || true
-          echo "Checkov scan complete (advisory)."
+            --hard-fail-on HIGH,CRITICAL
+          echo "Checkov scan complete."
 
   tfsec:
     name: Tfsec Terraform scan (fail on HIGH/CRITICAL)
     runs-on: ubuntu-latest
-    continue-on-error: true  # Non-blocking for PR evaluation
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install tfsec
         run: |
@@ -102,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true   # Advisory only — no Snyk auth configured
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Snyk (skipped — no auth configured)
         run: |
           echo "Snyk requires SNYK_TOKEN secret. Set it in GitHub Secrets to enable."

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -21,7 +21,7 @@ jobs:
     name: Validate docker-compose Configuration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Install Docker
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
@@ -31,13 +31,14 @@ jobs:
           if [ -f docker-compose.base.yml ] && [ -f docker-compose.yml ]; then
             docker compose -f docker-compose.base.yml config > /dev/null 2>&1 \
               && echo "✓ docker-compose.base.yml + docker-compose.yml composition valid" \
-              || echo "⚠ docker-compose composition validation failed (non-blocking)"
+              || (echo "❌ docker-compose composition validation failed"; exit 1)
           elif [ -f docker-compose.yml ]; then
             docker compose config > /dev/null 2>&1 \
               && echo "✓ docker-compose.yml syntax valid" \
-              || echo "⚠ docker-compose syntax validation failed (non-blocking)"
+              || (echo "❌ docker-compose syntax validation failed"; exit 1)
           else
-            echo "⚠ No docker-compose.yml found"
+            echo "❌ No docker-compose.yml found"
+            exit 1
           fi
 
   caddyfile-validate:
@@ -45,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     container: caddy:2-alpine
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Validate Caddyfile syntax
         run: |
@@ -54,16 +55,17 @@ jobs:
             sed '/^\s*dns cloudflare /d' Caddyfile > /tmp/Caddyfile.ci
             caddy validate --config /tmp/Caddyfile.ci \
               && echo "✓ Caddyfile syntax valid" \
-              || echo "⚠ Caddyfile validation failed in CI image (non-blocking)"
+              || (echo "❌ Caddyfile validation failed in CI image"; exit 1)
           else
-            echo "⚠ No Caddyfile found"
+            echo "❌ No Caddyfile found"
+            exit 1
           fi
 
   terraform-validate:
     name: Validate Terraform Configuration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -71,7 +73,7 @@ jobs:
           terraform_version: 1.7.0
       
       - name: Terraform format check
-        run: terraform fmt -check -recursive . || echo "⚠ Some files need formatting (non-blocking)"
+        run: terraform fmt -check -recursive .
       
       - name: Terraform validate
         run: |
@@ -83,7 +85,7 @@ jobs:
     name: Validate Shell Scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
@@ -105,17 +107,16 @@ jobs:
           done
       
       - name: Run ShellCheck
-        continue-on-error: true
         run: |
           if find scripts/ -name "*.sh" 2>/dev/null | head -1 | grep -q .; then
-            shellcheck scripts/*.sh || echo "⚠ ShellCheck warnings (non-blocking)"
+            shellcheck scripts/*.sh
           fi
 
   secrets-scan:
     name: Scan for Secrets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
       
@@ -126,7 +127,6 @@ jobs:
           base: ${{ github.event.pull_request.base.sha }}
           head: HEAD
           extra_args: --only-verified --allow-unverified=false 2>/dev/null
-        continue-on-error: true
       
       - name: Manual secret pattern check
         run: |
@@ -142,7 +142,7 @@ jobs:
     name: Check for Obsolete Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Check for phase-specific files at root
         run: |
@@ -186,8 +186,8 @@ jobs:
              [ "${{ needs.terraform-validate.result }}" == "failure" ] || \
              [ "${{ needs.shell-script-validate.result }}" == "failure" ]; then
             echo ""
-            echo "⚠ Some validation failures detected - review above"
-            exit 0
+            echo "❌ Validation failures detected - blocking"
+            exit 1
           else
             echo ""
             echo "✓ All validations passed"


### PR DESCRIPTION
## Summary\nImplements fail-closed behavior for security and configuration validation paths to align with P1 governance requirements and immutable IaC standards.\n\n## What changed\n- .github/workflows/security.yml\n  - Removed non-blocking continue-on-error from TruffleHog, Gitleaks, Checkov, and Tfsec jobs\n  - Converted Checkov from advisory soft-fail to fail on HIGH/CRITICAL (--hard-fail-on HIGH,CRITICAL)\n  - Pinned remaining ctions/checkout references to immutable SHA\n- .github/workflows/validate-config.yml\n  - Pinned all ctions/checkout uses to immutable SHA\n  - Converted docker-compose, Caddyfile, terraform fmt, shellcheck, and TruffleHog steps to blocking behavior\n  - Changed summary job to return non-zero on validation failure\n\n## Why\nCurrent open issues track fail-open behavior that can allow risky changes to merge undetected. This PR moves required paths to deterministic fail-closed enforcement.\n\n## Issue linkage\n- Partial for #307 (GOV-011 fail-closed enforcement)\n- Partial for #310 (supply chain pinning)\n\n## Notes\n- Snyk remains advisory due missing token configuration (unchanged).\n- Additional unpinned actions outside these two workflows remain tracked in #310.