### PR TITLE
feat(governance): add remediation issue template guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: "Architecture Decisions (ADRs)"
     url: "https://github.com/kushin77/code-server/blob/main/docs/adr/"
     about: "Review past architectural decisions before proposing changes"
+  - name: "Governance Policy + Remediation Guide"
+    url: "https://github.com/kushin77/code-server/blob/main/docs/governance/POLICY.md"
+    about: "Map CI policy failures to required remediation steps before opening a new issue"

--- a/.github/ISSUE_TEMPLATE/governance-remediation.md
+++ b/.github/ISSUE_TEMPLATE/governance-remediation.md
@@ -1,0 +1,49 @@
+---
+name: Governance remediation
+description: Track and remediate governance policy violations from CI or audits
+title: 'chore(governance): remediate <policy/check> violation in <scope>'
+labels: ["governance", "remediation"]
+assignees: ''
+---
+
+## Duplicate Check (required before submitting)
+
+- [ ] I searched [existing issues](https://github.com/kushin77/code-server/issues?q=is%3Aissue) for this remediation topic
+- [ ] No canonical open issue already tracks this same policy violation
+- [ ] If duplicate, I linked and closed in favor of canonical issue
+
+## Failing Signal
+
+- Check/workflow name:
+- Run URL:
+- Failing file(s):
+- Severity: P0 / P1 / P2 / P3
+
+## Policy Mapping
+
+- Governance policy section:
+- Required standard: immutable / idempotent / independent / duplicate-free / on-prem
+- Is waiver requested?: yes / no
+
+## Root Cause
+
+<!-- Why this violation exists today (not just the symptom) -->
+
+## Remediation Plan
+
+1. 
+2. 
+3. 
+
+## Verification
+
+- [ ] Local verification completed
+- [ ] CI check passes on PR
+- [ ] On-prem validation completed on 192.168.168.31 (if runtime-affecting)
+- [ ] No duplicate policy regressions introduced
+
+## Closure Criteria
+
+- [ ] PR includes `Fixes #N`
+- [ ] Superseded/duplicate issues linked and closed
+- [ ] Remaining follow-up work split into separate canonical issues


### PR DESCRIPTION
Refs #380\n\n## Summary\n- Add .github/ISSUE_TEMPLATE/governance-remediation.md\n- Capture canonical remediation fields: failing check/run URL, policy mapping, root cause, verification, closure criteria\n- Add governance policy contact link in issue template config for faster triage routing\n\n## Why\n#380 tracks creation of issue templates for remediation guidance. This adds a dedicated governance remediation intake path to reduce duplicate issue creation and improve fix-to-policy traceability.\n\n## Scope\n- GitHub issue templates only\n- No runtime/IaC service behavior changes\n- Supports immutable, duplicate-free governance operations