### PR TITLE
fix(ci): pin remaining mutable workflow actions (P2 #310)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: "Architecture Decisions (ADRs)"
     url: "https://github.com/kushin77/code-server/blob/main/docs/adr/"
     about: "Review past architectural decisions before proposing changes"
+  - name: "Governance Policy + Remediation Guide"
+    url: "https://github.com/kushin77/code-server/blob/main/docs/governance/POLICY.md"
+    about: "Map CI policy failures to required remediation steps before opening a new issue"

--- a/.github/ISSUE_TEMPLATE/governance-remediation.md
+++ b/.github/ISSUE_TEMPLATE/governance-remediation.md
@@ -1,0 +1,49 @@
+---
+name: Governance remediation
+description: Track and remediate governance policy violations from CI or audits
+title: 'chore(governance): remediate <policy/check> violation in <scope>'
+labels: ["governance", "remediation"]
+assignees: ''
+---
+
+## Duplicate Check (required before submitting)
+
+- [ ] I searched [existing issues](https://github.com/kushin77/code-server/issues?q=is%3Aissue) for this remediation topic
+- [ ] No canonical open issue already tracks this same policy violation
+- [ ] If duplicate, I linked and closed in favor of canonical issue
+
+## Failing Signal
+
+- Check/workflow name:
+- Run URL:
+- Failing file(s):
+- Severity: P0 / P1 / P2 / P3
+
+## Policy Mapping
+
+- Governance policy section:
+- Required standard: immutable / idempotent / independent / duplicate-free / on-prem
+- Is waiver requested?: yes / no
+
+## Root Cause
+
+<!-- Why this violation exists today (not just the symptom) -->
+
+## Remediation Plan
+
+1. 
+2. 
+3. 
+
+## Verification
+
+- [ ] Local verification completed
+- [ ] CI check passes on PR
+- [ ] On-prem validation completed on 192.168.168.31 (if runtime-affecting)
+- [ ] No duplicate policy regressions introduced
+
+## Closure Criteria
+
+- [ ] PR includes `Fixes #N`
+- [ ] Superseded/duplicate issues linked and closed
+- [ ] Remaining follow-up work split into separate canonical issues

--- a/.github/workflows/cost-monitoring.yml
+++ b/.github/workflows/cost-monitoring.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup environment
         run: |
@@ -287,7 +287,7 @@ jobs:
       pull-requests: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/phase-13-deploy.yml
+++ b/.github/workflows/phase-13-deploy.yml
@@ -36,7 +36,7 @@ jobs:
       # ────────────────────────────────────────────────────────────────────────
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -298,7 +298,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Check deployment artifacts
         run: |

--- a/.github/workflows/post-merge-cleanup-deploy.yml
+++ b/.github/workflows/post-merge-cleanup-deploy.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3.1.2
         with:
           terraform_version: 1.7.0
       

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -83,7 +83,7 @@ jobs:
     name: No Windows CI runners
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Detect windows-* runners
         run: |
@@ -104,7 +104,7 @@ jobs:
     name: Check for undefined secret references
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Detect secrets that should be in GitHub Secrets
         run: |
@@ -132,7 +132,7 @@ jobs:
     name: Workflows have name and permissions fields
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Validate name and permissions present
         run: |


### PR DESCRIPTION
## Summary
Session-aware follow-up to #310: pin remaining mutable action refs in active workflows to immutable SHAs.

## Changes
- phase-13-deploy.yml: ctions/checkout@v4 -> pinned SHA (2 spots)
- post-merge-cleanup-deploy.yml: ctions/checkout@v4 -> pinned SHA
- workflow-lint.yml: ctions/checkout@v4 -> pinned SHA (3 jobs)
- alidate-config.yml: hashicorp/setup-terraform@v3 -> pinned SHA (3.1.2)
- cost-monitoring.yml: ctions/checkout@v4 -> pinned SHA (2 jobs)

## Why
Advances immutable IaC/supply-chain policy and removes additional mutable action surfaces.

## Issue
Partial for #310