### PR TITLE
fix(ci): pin template workflow action refs to immutable SHAs (P2 #310)

### DIFF
--- a/.github/workflows/TEMPLATE-ci-build.yml
+++ b/.github/workflows/TEMPLATE-ci-build.yml
@@ -31,13 +31,13 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -56,7 +56,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
         with:
           context: .
           push: true

--- a/.github/workflows/TEMPLATE-ci-lint.yml
+++ b/.github/workflows/TEMPLATE-ci-lint.yml
@@ -30,12 +30,12 @@ jobs:
       checks: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 18
           cache: npm
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 5
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Spell check
         uses: crate-ci/typos@8e2e20556d0ec4fe80ca703f6fb5d89ed3ef2596  # master

--- a/.github/workflows/TEMPLATE-ci-security.yml
+++ b/.github/workflows/TEMPLATE-ci-security.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: true
 
       - name: Snyk scan
-        uses: snyk/actions/node@master
+        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04  # master (pinned)
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         continue-on-error: true
@@ -62,7 +62,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
@@ -76,7 +76,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@8344ad989e4d6f48107686f0ba4cadbf1a6f1b48  # v2.25.0
         if: always()
         with:
           sarif_file: semgrep.sarif
@@ -92,7 +92,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
@@ -104,7 +104,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@8344ad989e4d6f48107686f0ba4cadbf1a6f1b48  # v2.25.0
         if: always()
         with:
           sarif_file: trivy-results.sarif
@@ -120,7 +120,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/TEMPLATE-ci-tests.yml
+++ b/.github/workflows/TEMPLATE-ci-tests.yml
@@ -38,12 +38,12 @@ jobs:
       max-parallel: 2
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -113,10 +113,10 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 18
           cache: npm


### PR DESCRIPTION
## Summary
Final mutable-ref hardening slice for GOV-015 (#310): pin all remaining TEMPLATE workflow action refs to immutable commit SHAs.

## Changes
- TEMPLATE-ci-build.yml: pinned checkout, setup-buildx, login, metadata, build-push actions
- TEMPLATE-ci-lint.yml: pinned checkout and setup-node
- TEMPLATE-ci-security.yml: pinned checkout, snyk action commit, and codeql upload-sarif
- TEMPLATE-ci-tests.yml: pinned checkout and setup-node

## Result
- No mutable action refs remain (@v*, @main, @master, @HEAD, @latest) in .github/workflows.
- Supply-chain immutability posture is now consistent across active and template workflows.

Partial for #310 (remaining scope: least-privilege permissions tightening and workflow-policy documentation/audit refinements).