### PR TITLE
feat(governance): enforce immutable workflow policy audit + allowlist (P2 #310)

### DIFF
--- a/.github/workflows/TEMPLATE-ci-security.yml
+++ b/.github/workflows/TEMPLATE-ci-security.yml
@@ -11,7 +11,7 @@ on:
 env:
   COST_CATEGORY: "ci-security"
 
-  pull_request:
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -11,6 +11,8 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/**"
+  schedule:
+    - cron: '0 6 * * 1'
 
 permissions:
   contents: read
@@ -48,36 +50,50 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - name: Check for unpinned action versions (@master, @HEAD, @latest)
+      - name: Enforce immutable action SHA pinning
         run: |
           failed=0
-          # Pattern: uses: owner/repo@master or @HEAD or @latest
-          bad=$(grep -rn 'uses:.*@\(master\|HEAD\|latest\)' .github/workflows/ \
+          # Pattern: mutable refs are forbidden in all workflows (including templates)
+          bad=$(grep -rnE 'uses:.*@(v[0-9]+|main|master|HEAD|latest)\b' .github/workflows/ \
             --include="*.yml" --include="*.yaml" \
-            --exclude="TEMPLATE-*" \
             --exclude="workflow-lint.yml" || true)
           if [[ -n "$bad" ]]; then
-            echo "FAIL: Unpinned action versions detected (must use @vX.Y.Z or SHA):"
+            echo "FAIL: Mutable action refs detected (must pin to full commit SHA):"
             echo "$bad" | sed 's/^/  /'
             echo ""
-            echo "Pin to exact version tag (e.g. actions/checkout@v4)"
+            echo "Pin to exact commit SHA (e.g. actions/checkout@<40-hex-sha>)"
             failed=1
-          fi
-
-          # Also flag @v0 which is too loose
-          loose=$(grep -rn 'uses:.*@v0\b' .github/workflows/ \
-            --include="*.yml" --include="*.yaml" \
-            --exclude="TEMPLATE-*" \
-            --exclude="workflow-lint.yml" || true)
-          if [[ -n "$loose" ]]; then
-            echo "WARN: Loose action version @v0 detected (prefer specific tag):"
-            echo "$loose" | sed 's/^/  /'
           fi
 
           if [[ $failed -eq 1 ]]; then
             exit 1
           fi
-          echo "✓ All action versions are pinned"
+          echo "✓ All action refs are immutable"
+
+  permissions-hygiene:
+    name: Permissions hygiene check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Enforce top-level permissions and block write-all
+        run: |
+          failed=0
+          while IFS= read -r -d '' f; do
+            if ! grep -q '^permissions:' "$f"; then
+              echo "WARN: $f — missing top-level permissions block"
+            fi
+
+            if grep -qE 'permissions:\s*write-all' "$f"; then
+              echo "FAIL: $f — contains forbidden permissions: write-all"
+              failed=1
+            fi
+          done < <(find .github/workflows/ -name "*.yml" -print0)
+
+          if [[ $failed -eq 1 ]]; then
+            exit 1
+          fi
+          echo "✓ Permissions hygiene checks passed"
 
   no-windows-runners:
     name: No Windows CI runners

--- a/docs/governance/github-actions-allowlist.md
+++ b/docs/governance/github-actions-allowlist.md
@@ -1,0 +1,49 @@
+# GitHub Actions Approved Allowlist
+
+This document defines approved third-party GitHub Actions and the update process for immutable pinning.
+
+## Policy
+
+- All external actions in `.github/workflows` must be pinned to full commit SHAs.
+- Mutable refs are forbidden: `@v*`, `@main`, `@master`, `@HEAD`, `@latest`.
+- Top-level `permissions` is required in every workflow.
+- `permissions: write-all` is forbidden.
+
+## Approved Actions
+
+- `actions/checkout`
+- `actions/setup-node`
+- `actions/setup-python`
+- `actions/cache`
+- `docker/setup-buildx-action`
+- `docker/login-action`
+- `docker/metadata-action`
+- `docker/build-push-action`
+- `github/codeql-action/upload-sarif`
+- `trufflesecurity/trufflehog`
+- `aquasecurity/trivy-action`
+- `returntocorp/semgrep-action`
+- `snyk/actions/node`
+- `EnricoMi/publish-unit-test-result-action`
+- `codecov/codecov-action`
+- `crate-ci/typos`
+
+## Update Process
+
+1. Resolve the target version to a commit SHA using GitHub API:
+   - `gh api repos/<owner>/<repo>/git/ref/tags/<tag> --jq '.object.sha'`
+   - For branch-only actions, resolve commit directly and record rationale.
+2. Open a dedicated PR with scope limited to action pin updates.
+3. Include before/after refs in PR body.
+4. Run `Workflow Lint` and security checks.
+5. Merge only after checks pass (or approved emergency process).
+
+## Emergency Exception Handling
+
+- If a security fix requires temporary mutable refs, create an issue with severity and ETA.
+- Exception must be removed in the next PR and linked back to the issue.
+
+## Ownership
+
+- Primary owner: Platform Engineering
+- Canonical tracking issue: #310


### PR DESCRIPTION
## Summary
Advance GOV-015 (#310) with policy enforcement and operational governance artifacts.

## Changes
- workflow-lint.yml
  - add weekly schedule trigger (periodic audit)
  - enforce mutable-ref blocking (@v*, @main, @master, @HEAD, @latest)
  - add permissions hygiene check (blocks write-all, warns on missing top-level permissions)
- TEMPLATE-ci-security.yml
  - fix malformed key: pull_request -> concurrency
- docs/governance/github-actions-allowlist.md
  - approved actions allowlist
  - SHA pin update procedure
  - exception handling and ownership

## Why
Closes remaining #310 acceptance criteria slices for policy audit and documented allowlist, while preserving no-wait governance execution and immutable action posture.

Related: #310