### PR TITLE
feat(quality): enforce rollout evidence in production readiness gate (#381)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -126,6 +126,20 @@ Test duration:     [Minutes]
 - [ ] Rollout strategy documented (1% → 10% → 50% → 100%)
 - [ ] Kill switch procedure documented (how to disable if issues found)
 
+### Rollout Enforcement
+- [ ] Deployment strategy selected and justified for this PR
+- [ ] Gradual rollout increments documented or marked not applicable
+- [ ] Kill switch or immediate rollback command documented
+- [ ] Feature flag reference documented or marked not applicable
+- [ ] Waiver issue linked or marked not needed
+- [ ] Training evidence linked (runbook walkthrough, owner, and date)
+
+**Waiver issue**:
+`none` or `#<issue-number>`
+
+**Training evidence**:
+`[Link to runbook review, training note, or approval comment]`
+
 **Rollback Plan**:
 - [ ] Time to rollback: [X minutes]
 - [ ] Rollback command: `[git revert / terraform destroy / helm rollback / etc.]`

--- a/.github/workflows/production-readiness-gate.yml
+++ b/.github/workflows/production-readiness-gate.yml
@@ -52,10 +52,44 @@ jobs:
                 problems.push("For non-trivial changes, check: 'Production readiness gate acknowledged'.");
               }
 
+              const rolloutChecks = [
+                /- \[x\] Deployment strategy selected and justified for this PR/i,
+                /- \[x\] Gradual rollout increments documented or marked not applicable/i,
+                /- \[x\] Kill switch or immediate rollback command documented/i,
+                /- \[x\] Feature flag reference documented or marked not applicable/i,
+                /- \[x\] Waiver issue linked or marked not needed/i,
+                /- \[x\] Training evidence linked \(runbook walkthrough, owner, and date\)/i,
+              ];
+
+              if (!rolloutChecks.every((pattern) => pattern.test(body))) {
+                problems.push("For non-trivial changes, complete the Rollout Enforcement section in the PR template.");
+              }
+
+              const waiverMatch = body.match(/\*\*Waiver issue\*\*:\s*`([^`]+)`/i);
+              if (!waiverMatch) {
+                problems.push("Document '**Waiver issue**' as `none` or `#<issue-number>`.");
+              } else {
+                const waiverValue = waiverMatch[1].trim();
+                if (!/^none$/i.test(waiverValue) && !/^#\d+$/i.test(waiverValue)) {
+                  problems.push("Waiver issue must be `none` or a single issue reference like `#123`.");
+                }
+              }
+
+              const trainingMatch = body.match(/\*\*Training evidence\*\*:\s*`([^`]+)`/i);
+              if (!trainingMatch) {
+                problems.push("Document '**Training evidence**' with a concrete link or comment reference.");
+              } else {
+                const trainingValue = trainingMatch[1].trim();
+                if (/^\[link to /i.test(trainingValue) || /^todo$/i.test(trainingValue)) {
+                  problems.push("Replace training evidence placeholder with a real link or approval comment.");
+                }
+              }
+
               const placeholders = [
                 "[Describe failure scenarios and their impact]",
                 "[Alerts, logs, metrics, or manual checks]",
                 "[Add any additional context, screenshots, links, or considerations here]",
+                "[Link to runbook review, training note, or approval comment]",
               ];
               for (const token of placeholders) {
                 if (body.includes(token)) {

--- a/docs/governance/production-readiness-training.md
+++ b/docs/governance/production-readiness-training.md
@@ -1,0 +1,41 @@
+# Production Readiness Gate Training
+
+## Purpose
+
+This document is the training artifact for issue #381 and the production-readiness gate process.
+
+## Audience
+
+- PR authors for non-trivial changes
+- Non-author peer reviewers
+- On-call and operations reviewers
+
+## Required Outcomes
+
+After this walkthrough, the reviewer and author should be able to:
+
+1. Classify a PR as trivial or non-trivial.
+2. Complete the Phase 1-4 readiness sections in the PR template.
+3. Provide rollout evidence, rollback evidence, and waiver traceability.
+4. Attach load-test and post-deploy certification evidence.
+
+## Walkthrough Agenda
+
+1. Review the PR template readiness sections.
+2. Review the runbook: docs/runbooks/production-readiness-gate.md.
+3. Run the baseline load-test harness: scripts/loadtest/k6-baseline.js.
+4. Validate rollback command and incident drill path.
+5. Record approval comment link in the PR `Training evidence` field.
+
+## Evidence Template
+
+- Reviewer:
+- Date:
+- PR:
+- Approval comment or note link:
+- Follow-up actions:
+
+## Owner
+
+- Primary owner: Platform Engineering
+- Canonical tracking issue: #381

--- a/docs/runbooks/production-readiness-gate.md
+++ b/docs/runbooks/production-readiness-gate.md
@@ -34,6 +34,16 @@ Applies to all non-trivial pull requests that modify runtime behavior, infrastru
 4. Verify deployment strategy and rollback command are documented.
 5. Ensure readiness-gate CI check passes before merge.
 
+## Rollout Verification
+
+For non-trivial changes, capture rollout evidence directly in the PR body.
+
+1. Select one deployment strategy: rolling, blue-green, canary, or feature-flag.
+2. If using canary or feature-flag, document explicit rollout increments (for example: 1% -> 10% -> 50% -> 100%).
+3. Record the kill switch or rollback command that can be executed in under 60 seconds.
+4. Link any waiver issue if a gate is overridden; otherwise record `none`.
+5. Attach training evidence showing the on-call/operator walkthrough was completed.
+
 ## Incident Drill Procedure
 
 1. Simulate a controlled failure in staging.
@@ -47,6 +57,15 @@ Applies to all non-trivial pull requests that modify runtime behavior, infrastru
 2. Include reason, compensating controls, and expiration date.
 3. Add link to waiver issue in PR body.
 4. Post-merge, close waiver issue only after corrective action is delivered.
+
+## Training Evidence
+
+Training evidence must exist before merge for non-trivial changes.
+
+1. Review this runbook with the assigned non-author reviewer or on-call owner.
+2. Capture the reviewer, date, and link to the approval comment or note.
+3. Add that link to the `Training evidence` field in the PR template.
+4. If training is deferred, open a waiver issue with expiration and compensating controls.
 
 ## Evidence Requirements
 


### PR DESCRIPTION
## Summary
Advance #381 by enforcing the remaining pre-review production-readiness gaps around rollout verification, waiver traceability, and training evidence.

## Changes
- .github/pull_request_template.md
  - add machine-checkable rollout enforcement checklist
  - add explicit Waiver issue and Training evidence fields
- .github/workflows/production-readiness-gate.yml
  - fail non-trivial PRs that omit rollout, waiver, or training evidence
  - validate waiver field is 
one or #<issue>
  - reject placeholder training links
- docs/runbooks/production-readiness-gate.md
  - add rollout verification and training evidence procedures
- docs/governance/production-readiness-training.md
  - add dedicated training artifact for gate adoption

## Why
A previous session delivered the #381 scaffold, but the issue still called out concrete rollout enforcement and training evidence as remaining scope. This PR closes that gap without duplicating earlier work.

Fixes #381