### PR TITLE
fix(ci): repair deploy workflow reliability + fail-closed dispatch (#308)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,16 @@ on:
     paths:
       - 'terraform/**'
       - '.github/workflows/deploy.yml'
-  workflow_dispatch:  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Deployment action to run'
+        required: true
+        default: deploy
+        type: choice
+        options:
+          - deploy
+          - destroy
 
 # Ref: #390 — least-privilege permissions (deny write by default)
 # TODO: pin all action refs to commit SHAs via Renovate (#358)
@@ -22,6 +31,7 @@ jobs:
   validate:
     name: Validate Terraform
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy')
     permissions:
       contents: read
 
@@ -45,6 +55,7 @@ jobs:
     name: Plan Deployment
     runs-on: ubuntu-latest
     needs: validate
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy')
     permissions:
       contents: read
       pull-requests: write  # allows posting plan summary as PR comment
@@ -72,10 +83,13 @@ jobs:
     name: Apply Deployment
     runs-on: ubuntu-latest
     needs: plan
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy')
     # Ref: #390 — requires environment protection (branch + reviewer approval)
-    # Create a "production" environment in GitHub → Settings → Environments
+    # Create a "production" environment in GitHub -> Settings -> Environments
     environment: production
+    concurrency:
+      group: deploy-production-control
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write  # allows OIDC token for cloud provider auth (no long-lived secrets)
@@ -100,7 +114,7 @@ jobs:
 
       - name: Get Outputs
         run: |
-          echo "## Deployment Complete ✅" >> $GITHUB_STEP_SUMMARY
+          echo "## Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Access URL:** $(terraform output -raw code_server_url)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -112,7 +126,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Code-Server Enterprise Deployed ✅",
+              "text": "Code-Server Enterprise Deployed",
               "blocks": [
                 {
                   "type": "section",
@@ -127,9 +141,12 @@ jobs:
   destroy:
     name: Destroy (Manual Only)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && contains(github.event.inputs.action, 'destroy')
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'destroy'
     # Ref: #390 — destructive operation requires explicit approval
     environment: production-destroy
+    concurrency:
+      group: deploy-production-control
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write
@@ -169,3 +186,56 @@ jobs:
                 }
               ]
             }
+
+  final-status:
+    name: Final Deploy Status
+    runs-on: ubuntu-latest
+    needs: [validate, plan, apply, destroy]
+    if: always()
+    permissions:
+      contents: read
+    steps:
+      - name: Evaluate workflow result
+        run: |
+          validate_result="${{ needs.validate.result }}"
+          plan_result="${{ needs.plan.result }}"
+          apply_result="${{ needs.apply.result }}"
+          destroy_result="${{ needs.destroy.result }}"
+
+          event="${{ github.event_name }}"
+          action="${{ github.event.inputs.action || '' }}"
+
+          echo "## Deploy Workflow Result" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Event: $event" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Action: ${action:-n/a}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- validate: $validate_result" >> "$GITHUB_STEP_SUMMARY"
+          echo "- plan: $plan_result" >> "$GITHUB_STEP_SUMMARY"
+          echo "- apply: $apply_result" >> "$GITHUB_STEP_SUMMARY"
+          echo "- destroy: $destroy_result" >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$event" == "push" ]]; then
+            [[ "$validate_result" == "success" && "$plan_result" == "success" && "$apply_result" == "success" ]] || {
+              echo "Push deployment path failed" >&2
+              exit 1
+            }
+            exit 0
+          fi
+
+          if [[ "$event" == "workflow_dispatch" && "$action" == "deploy" ]]; then
+            [[ "$validate_result" == "success" && "$plan_result" == "success" && "$apply_result" == "success" && "$destroy_result" == "skipped" ]] || {
+              echo "Manual deploy path failed" >&2
+              exit 1
+            }
+            exit 0
+          fi
+
+          if [[ "$event" == "workflow_dispatch" && "$action" == "destroy" ]]; then
+            [[ "$destroy_result" == "success" && "$validate_result" == "skipped" && "$plan_result" == "skipped" && "$apply_result" == "skipped" ]] || {
+              echo "Manual destroy path failed" >&2
+              exit 1
+            }
+            exit 0
+          fi
+
+          echo "Unhandled event/action combination" >&2
+          exit 1

--- a/.github/workflows/post-merge-cleanup-deploy.yml
+++ b/.github/workflows/post-merge-cleanup-deploy.yml
@@ -72,13 +72,13 @@ jobs:
         run: |
           BRANCH="${{ needs.check-merge.outputs.branch }}"
           echo "🗑️ Cleaning up branch: $BRANCH"
-          
+
           # Don't delete protected branches
           if [[ "$BRANCH" =~ ^(main|develop|release|hotfix)$ ]]; then
             echo "⚠️ Skipping protected branch: $BRANCH"
             exit 0
           fi
-          
+
           # Try to delete remote branch
           if git push origin --delete "$BRANCH" 2>/dev/null; then
             echo "✅ Successfully deleted remote branch: $BRANCH"
@@ -117,7 +117,7 @@ jobs:
           script: |
             const prNum = '${{ needs.check-merge.outputs.pr_number }}';
             console.log(`🚀 Triggering deployment pipeline for PR #${prNum}`);
-            
+
             // Create deployment record
             await github.rest.repos.createDeployment({
               owner: context.repo.owner,
@@ -130,37 +130,67 @@ jobs:
             });
 
       - name: Trigger Deploy Workflow
+        id: dispatch
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
-        continue-on-error: true
         with:
           script: |
             console.log('📋 Dispatching deployment workflow...');
-            
-            try {
-              const response = await github.rest.actions.createWorkflowDispatch({
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'deploy.yml',
+              ref: 'main',
+              inputs: {
+                action: 'deploy'
+              }
+            });
+
+            const dispatchedAt = new Date().toISOString();
+            core.setOutput('dispatched_at', dispatchedAt);
+            console.log(`✅ Deployment workflow dispatched at ${dispatchedAt}`);
+
+      - name: Verify Deploy Workflow Dispatch
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const dispatchedAt = '${{ steps.dispatch.outputs.dispatched_at }}';
+            const dispatchedAtMs = Date.parse(dispatchedAt);
+
+            if (Number.isNaN(dispatchedAtMs)) {
+              core.setFailed('Dispatch timestamp was not recorded; failing closed.');
+              return;
+            }
+
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const maxAttempts = 12;
+            const delayMs = 5000;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const runs = await github.rest.actions.listWorkflowRuns({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: 'deploy.yml',
-                ref: 'main',
-                inputs: {
-                  trigger_source: 'auto-merge-pipeline',
-                  pr_number: '${{ needs.check-merge.outputs.pr_number }}'
-                }
+                branch: 'main',
+                event: 'workflow_dispatch',
+                per_page: 20
               });
-              
-              console.log('✅ Deployment workflow dispatched');
-              return response;
-            } catch (error) {
-              if (error.message.includes('Could not resolve to a repository')) {
-                console.warn('⚠️ Deployment workflow not found, but proceeding with redeploy');
-              } else if (error.message.includes('Resource not accessible') || error.status === 403) {
-                console.warn('⚠️ Workflow dispatch permission denied - deployment trigger deferred');
-                console.warn('   This is normal if deploy.yml has restricted permissions');
-                console.warn('   Cleanup and issue closure are complete and working');
-              } else {
-                throw error;
+
+              const foundRun = runs.data.workflow_runs.find((run) => {
+                const createdMs = Date.parse(run.created_at);
+                return !Number.isNaN(createdMs) && createdMs >= dispatchedAtMs - 10000;
+              });
+
+              if (foundRun) {
+                console.log(`✅ Verified dispatched run: ${foundRun.html_url}`);
+                return;
               }
+
+              console.log(`⏳ Awaiting deploy workflow run registration (${attempt}/${maxAttempts})...`);
+              await sleep(delayMs);
             }
+
+            core.setFailed('Deploy workflow dispatch did not register a run within the expected window.');
 
   close-related-issues:
     name: Auto-Close Resolved Issues
@@ -173,7 +203,7 @@ jobs:
         with:
           script: |
             const prNum = '${{ needs.check-merge.outputs.pr_number }}';
-            
+
             if (prNum === 'push-event') {
               console.log('ℹ️ Push event detected - skipping issue auto-close');
               return;
@@ -191,7 +221,7 @@ jobs:
             // Extract issue numbers from PR body (e.g., "Closes #123", "Fixes #456")
             const body = pr.data.body || '';
             const issueMatches = body.match(/(?:clos|fix|resolv)(?:es|ed)?\s+#(\d+)/gi);
-            
+
             if (!issueMatches) {
               console.log('ℹ️ No linked issues found in PR body');
               return;


### PR DESCRIPTION
## Summary
Implements P1 reliability hardening for deploy automation in #308 with deterministic manual paths and fail-closed dispatch verification.

## Changes
- deploy.yml
  - adds explicit workflow_dispatch.inputs.action (deploy|destroy)
  - routes validate/plan/apply only for push or manual deploy action
  - routes destroy only for explicit manual destroy action
  - adds shared concurrency guard to prevent overlapping apply/destroy operations
  - adds final status gate job to fail closed on invalid event/action result combinations
- post-merge-cleanup-deploy.yml
  - removes continue-on-error from deploy dispatch
  - dispatches deploy.yml with explicit ction: deploy
  - verifies dispatched workflow run is actually registered; fails closed if not observed

## Why
Addresses issue #308 defects: ambiguous manual destroy conditions, non-deterministic manual dispatch behavior, and post-merge false success when dispatch fails.

Fixes #308