### PR TITLE
fix(docs): repair README structure/runtime truth + CI markdown checks (#327)

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -75,6 +75,44 @@ jobs:
           fi
           echo "✅ Zero governance violations"
 
+  readme-docs-integrity:
+    name: README docs integrity (markdown + local links)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Install markdownlint-cli
+        run: |
+          set -euo pipefail
+          sudo npm install -g markdownlint-cli@0.39.0
+
+      - name: Lint README markdown structure
+        run: |
+          set -euo pipefail
+          markdownlint README.md
+
+      - name: Validate README local markdown links
+        run: |
+          set -euo pipefail
+          failures=0
+          # Validate only local relative links: [text](path)
+          while IFS= read -r raw; do
+            target=$(echo "$raw" | sed -E 's/^.*\]\(([^)#]+)(#[^)]+)?\).*/\1/')
+            # Skip URLs, mailto, and empty anchors.
+            if [[ "$target" =~ ^https?:// ]] || [[ "$target" =~ ^mailto: ]] || [[ -z "$target" ]]; then
+              continue
+            fi
+            if [[ ! -e "$target" ]]; then
+              echo "::error::README link target does not exist: $target"
+              failures=1
+            fi
+          done < <(grep -oE '\[[^]]+\]\(([^)]+)\)' README.md || true)
+
+          if [[ "$failures" -ne 0 ]]; then
+            exit 1
+          fi
+          echo "README local link check passed"
+
   # Ref: #400 — explicit shellcheck job (also run via pre-commit above; this gives
   # clear per-file annotations in the PR diff view)
   shellcheck:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ COMPOSE_PROFILES=ai docker compose up -d
 COMPOSE_PROFILES=monitoring,tracing,ai docker compose up -d
 ```
 
+## Run Mode Matrix
+
+| Mode | Compose command | Includes |
+|---|---|---|
+| IDE-only | `docker compose up -d` | code-server, oauth2-proxy, caddy, postgres, redis |
+| IDE + AI | `COMPOSE_PROFILES=ai docker compose up -d` | IDE-only + ollama |
+| IDE + Observability | `COMPOSE_PROFILES=monitoring,tracing docker compose up -d` | IDE-only + prometheus, grafana, alertmanager, loki, promtail, otel-collector, jaeger |
+| Full platform | `COMPOSE_PROFILES=monitoring,tracing,ai docker compose up -d` | IDE, AI, and observability stack |
+
 ## Services
 
 | Service | Port | Profile | Notes |
@@ -56,9 +65,11 @@ cd code-server-enterprise
 docker compose up -d
 ```
 
+For AI or observability in production, use the same profile flags from `Quick Start` on host `192.168.168.31`.
+
 ## Architecture
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) and [ADR-001](ADR-001-CLOUDFLARE-TUNNEL-ARCHITECTURE.md).
+See [ARCHITECTURE.md](ARCHITECTURE.md), [ADR index](docs/adr/README.md), and [Cloudflare tunnel ADR](docs/adr/006-cloudflare-tunnel-architecture.md).
 
 ## Contributing
 


### PR DESCRIPTION
## Summary\n- add explicit run-mode matrix for IDE-only, IDE+AI, IDE+observability, and full stack\n- fix broken architecture ADR reference in README\n- clarify production profile usage on host 192.168.168.31\n- add fail-closed README docs integrity job in ci-validate workflow\n  - markdownlint on README.md\n  - local relative link existence validation\n\n## Why\nIssue #327 called out structural/readability integrity risk and stale/broken references. This PR restores operator-safe quick-start documentation and adds CI enforcement to prevent regression.\n\n## Validation\n- workflow YAML diagnostics: clean\n- README diagnostics: clean\n\nFixes #327