### PR TITLE
fix(ops): eliminate active hardcoded host fallbacks via SSOT config (#298)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,8 +38,8 @@ repos:
       - id: no-hardcoded-ips
         name: No hardcoded IP addresses in scripts
         entry: bash -c '
-          files=$(grep -rl "192\.168\.168\.\(31\|30\)" scripts/ 2>/dev/null \
-            | grep -v "_common/" | grep -v "config\.sh" | grep "\.sh$")
+          files=$(grep -rlE "192\.168\.168\.\(31\|30\)|:-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" scripts/ 2>/dev/null \
+            | grep -v "_common/" | grep -v "_archive/" | grep -v "scripts/lib/" | grep -v "config\.sh" | grep "\.sh$")
           if [[ -n "$files" ]]; then
             echo "GOVERNANCE: Hardcoded IP — use \$DEPLOY_HOST from _common/config.sh:"
             echo "$files" | sed "s/^/  /"; exit 1

--- a/scripts/_common/config.sh
+++ b/scripts/_common/config.sh
@@ -39,6 +39,13 @@ readonly DEPLOY_DIR="${DEPLOY_DIR:-/home/akushnir/code-server-enterprise}"
 readonly STANDBY_HOST="${STANDBY_HOST:-192.168.168.30}"
 readonly STANDBY_USER="${STANDBY_USER:-akushnir}"
 
+# Region host list (optional overrides for additional regions)
+readonly REGION_HOST_3="${REGION_HOST_3:-}"
+readonly REGION_HOST_4="${REGION_HOST_4:-}"
+REGION_HOSTS=("${DEPLOY_HOST}" "${STANDBY_HOST}")
+[[ -n "${REGION_HOST_3}" ]] && REGION_HOSTS+=("${REGION_HOST_3}")
+[[ -n "${REGION_HOST_4}" ]] && REGION_HOSTS+=("${REGION_HOST_4}")
+
 # SSH options (no interactive prompts in CI)
 readonly SSH_OPTS="${SSH_OPTS:--o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10}"
 

--- a/scripts/automated-certificate-management.sh
+++ b/scripts/automated-certificate-management.sh
@@ -10,7 +10,6 @@ source "$SCRIPT_DIR/_common/init.sh" || { echo "FATAL: Cannot source _common/ini
 CERT_DIR="${SCRIPT_DIR}/certs"
 ACME_EMAIL="${ACME_EMAIL:-admin@kushnir.cloud}"
 DOMAIN="${DOMAIN:-ide.kushnir.cloud}"
-DEPLOY_HOST="${DEPLOY_HOST:-192.168.168.31}"
 
 echo "====== AUTOMATED SSL/TLS CERTIFICATE MANAGEMENT ======"
 echo ""

--- a/scripts/automated-deployment-orchestration.sh
+++ b/scripts/automated-deployment-orchestration.sh
@@ -58,7 +58,6 @@ PARENT_DIR="$(dirname "$SCRIPT_DIR")"
 
 # Configuration from environment
 DOMAIN="${DOMAIN:-ide.kushnir.cloud}"
-DEPLOY_HOST="${DEPLOY_HOST:-192.168.168.31}"
 DEPLOY_USER="${DEPLOY_USER:-akushnir}"
 DEPLOY_ENV="${DEPLOY_ENV:-production}"
 DEPLOYMENT_DIR="/home/${DEPLOY_USER}/code-server-immutable-$(date +%Y%m%d-%H%M%S)"

--- a/scripts/automated-env-generator.sh
+++ b/scripts/automated-env-generator.sh
@@ -81,7 +81,6 @@ GOOGLE_CLIENT_SECRET="${GOOGLE_CLIENT_SECRET:-}"
 
 # Domain Configuration
 DOMAIN="${DOMAIN:-ide.kushnir.cloud}"
-DEPLOY_HOST="${DEPLOY_HOST:-192.168.168.31}"
 DEPLOY_ENV="${DEPLOY_ENV:-production}"
 
 # Generate credentials

--- a/scripts/configure-audit-logging-phase4.sh
+++ b/scripts/configure-audit-logging-phase4.sh
@@ -6,6 +6,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common/init.sh" || { echo "FATAL: Cannot source _common/init.sh"; exit 1; }
+
 # Color codes
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -19,7 +22,7 @@ log_warning() { echo -e "${YELLOW}[!]${NC} $*"; }
 log_error() { echo -e "${RED}[✗]${NC} $*" >&2; }
 
 # === Configuration ===
-POSTGRES_HOST="${POSTGRES_HOST:-192.168.168.31}"
+POSTGRES_HOST="${POSTGRES_HOST:-${DEPLOY_HOST}}"
 POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 POSTGRES_DB="${POSTGRES_DB:-code_server_prod}"
 POSTGRES_USER="${POSTGRES_USER:-postgres}"

--- a/scripts/deploy-oidc-issuer-phase2-1.sh
+++ b/scripts/deploy-oidc-issuer-phase2-1.sh
@@ -10,13 +10,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+source "$SCRIPT_DIR/_common/init.sh" || { echo "FATAL: Cannot source _common/init.sh"; exit 1; }
 
 OIDC_NAMESPACE="oidc-issuer"
 OIDC_ISSUER_URL="https://oidc.kushnir.cloud"
 OIDC_ISSUER_SERVICE="oidc-issuer.oidc-issuer.svc.cluster.local:8888"
 APEX_DOMAIN="kushnir.cloud"
-PRIMARY_HOST="192.168.168.31"
-REPLICA_HOST="192.168.168.42"
+PRIMARY_HOST="${PRIMARY_HOST:-${DEPLOY_HOST}}"
+REPLICA_HOST="${REPLICA_HOST:-${STANDBY_HOST}}"
 
 # Color output
 RED='\033[0;31m'

--- a/scripts/deploy-oidc-issuer-phase2-v2.sh
+++ b/scripts/deploy-oidc-issuer-phase2-v2.sh
@@ -16,9 +16,10 @@ trap 'log_error "Script failed at line $LINENO with exit code $?"' ERR
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PHASE2_DIR="$ROOT_DIR/config/iam"
+source "$SCRIPT_DIR/_common/init.sh" || { echo "FATAL: Cannot source _common/init.sh"; exit 1; }
 
 # Configuration
-OIDC_HOST="${DEPLOY_HOST:-192.168.168.31}"
+OIDC_HOST="${OIDC_HOST:-${DEPLOY_HOST}}"
 OIDC_PORT="${OIDC_PORT:-8080}"
 OIDC_PATH="/oidc"
 OIDC_URL="https://${OIDC_HOST}:${OIDC_PORT}${OIDC_PATH}"
@@ -173,7 +174,7 @@ cat > "$SCRIPT_DIR/test-oidc-endpoint.sh" <<'TEST_EOF'
 #!/bin/bash
 set -euo pipefail
 
-OIDC_HOST="${1:-192.168.168.31}"
+OIDC_HOST="${1:-${DEPLOY_HOST}}"
 OIDC_PORT="${2:-8080}"
 OIDC_URL="https://${OIDC_HOST}:${OIDC_PORT}"
 

--- a/scripts/deploy-rbac-enforcement-docker-phase3.sh
+++ b/scripts/deploy-rbac-enforcement-docker-phase3.sh
@@ -6,8 +6,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+source "$SCRIPT_DIR/_common/init.sh" || { echo "FATAL: Cannot source _common/init.sh"; exit 1; }
 
-DOCKER_HOST="${DOCKER_HOST:-192.168.168.31}"
+DOCKER_HOST="${DOCKER_HOST:-${DEPLOY_HOST}}"
 APEX_DOMAIN="${APEX_DOMAIN:-kushnir.cloud}"
 COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yml"
 

--- a/scripts/deployment-validation-suite.sh
+++ b/scripts/deployment-validation-suite.sh
@@ -8,7 +8,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_common/init.sh" || { echo "FATAL: Cannot source _common/init.sh"; exit 1; }
 
 DOMAIN="${DOMAIN:-ide.kushnir.cloud}"
-DEPLOY_HOST="${DEPLOY_HOST:-192.168.168.31}"
 DEPLOY_USER="${DEPLOY_USER:-akushnir}"
 VALIDATION_REPORT="${SCRIPT_DIR}/DEPLOYMENT-VALIDATION-REPORT.md"
 

--- a/scripts/keepalived-notify.sh
+++ b/scripts/keepalived-notify.sh
@@ -14,13 +14,16 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common/init.sh" || { echo "FATAL: Cannot source _common/init.sh"; exit 1; }
+
 # ==============================================================================
 # CONFIGURATION
 # ==============================================================================
 
 STATE="${1:-UNKNOWN}"
 HOSTNAME="$(hostname)"
-VIP="${PROD_VIP:-192.168.168.30}"
+VIP="${PROD_VIP:-${STANDBY_HOST}}"
 LOG_FILE="/var/log/keepalived-notify.log"
 
 # Logging

--- a/scripts/pre-flight-checklist.sh
+++ b/scripts/pre-flight-checklist.sh
@@ -189,7 +189,6 @@ echo "📋 PHASE 7: NETWORK & SSH CONNECTIVITY"
 echo "═════════════════════════════════════════════════════════════"
 echo ""
 
-DEPLOY_HOST="${DEPLOY_HOST:-192.168.168.31}"
 DEPLOY_USER="${DEPLOY_USER:-akushnir}"
 
 # Test SSH connectivity


### PR DESCRIPTION
## Summary
Session-aware #298 remediation applied to currently active scripts in this repository (original phase-7 file paths in issue body are no longer present in tree).

## Changes
- Added REGION_HOSTS support in `scripts/_common/config.sh`
- Strengthened `.pre-commit-config.yaml` `no-hardcoded-ips` to detect `${VAR:-<ip>}` fallback patterns
- Replaced hardcoded `.31/.30` fallbacks in active scripts with SSOT host variables from `_common/init.sh`/`config.sh`

## Files Updated
- `.pre-commit-config.yaml`
- `scripts/_common/config.sh`
- `scripts/automated-certificate-management.sh`
- `scripts/automated-deployment-orchestration.sh`
- `scripts/automated-env-generator.sh`
- `scripts/configure-audit-logging-phase4.sh`
- `scripts/deploy-oidc-issuer-phase2-1.sh`
- `scripts/deploy-oidc-issuer-phase2-v2.sh`
- `scripts/deploy-rbac-enforcement-docker-phase3.sh`
- `scripts/deployment-validation-suite.sh`
- `scripts/keepalived-notify.sh`
- `scripts/pre-flight-checklist.sh`

## Validation
- Active-script scan (excluding `_archive`, `_common`, `scripts/lib`) showed no remaining hardcoded `192.168.168.31/30` patterns
- No diagnostics errors in modified files

Fixes #298