### PR TITLE
fix(ci): enforce metadata headers on new scripts (#297 - incremental)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,15 +22,25 @@ repos:
         pass_filenames: false
         stages: [commit]
 
-      # Phase 2.3: Custom hook - verify metadata headers
+      # Phase 2.3: Custom hook - verify metadata headers (ENHANCED for #297)
       - id: verify-metadata-headers
         name: Verify metadata headers in critical scripts
-        entry: >-
-          bash -c '[[ -f scripts/deploy.sh ]] &&
-          ! grep -q "^# File:" scripts/deploy.sh &&
-          echo "ERROR: deploy.sh missing metadata header"'
+        entry: bash -c '
+          # Check only newly ADDED files (--diff-filter=A) to avoid retrofitting all scripts at once
+          new_scripts=$(git diff --cached --name-only --diff-filter=A -- "scripts/*.sh" "scripts/**/*.sh" 2>/dev/null | grep -v "_common/" | grep -v "_archive/")
+          if [[ -n "$new_scripts" ]]; then
+            missing_headers=0
+            for f in $new_scripts; do
+              if ! head -3 "$f" | grep -qE "@file|@module|@description"; then
+                echo "ERROR: $f missing @file/@module/@description metadata header"
+                missing_headers=$((missing_headers + 1))
+              fi
+            done
+            [[ $missing_headers -gt 0 ]] && exit 1
+          fi
+        '
         language: system
-        files: '^scripts/deploy\.sh$'
+        files: '^scripts/.*\.sh$'
         pass_filenames: false
         stages: [commit]
 


### PR DESCRIPTION
## Summary
Incremental #297 advancement: enforce @file/@module/@description metadata headers on all newly created scripts via pre-commit hook.

## Approach
- Updated `verify-metadata-headers` hook to only gate NEW scripts (--diff-filter=A)
- Avoids massive retrofit of 100+ existing scripts in one change
- Forward governance: all future script additions must comply
- Preserves existing script modifications without forcing header additions

## Changes
- `.pre-commit-config.yaml`: Enhanced hook with incremental enforcement

## Why
Establishes metadata governance boundary incrementally while prioritizing operational stability.

## Next Steps for #297
- Bulk migration helper script (optional, P3)
- MANIFEST.toml cross-reference (P3)
- CI discovery job for coverage reporting (P3)

Partial for #297