### PR TITLE
feat(infra): Phase 7d-001: Cloudflare Tunnel DNS Setup (P1 #351)

### DIFF
--- a/.github/workflows/phase-7d-cloudflare-validation.yml
+++ b/.github/workflows/phase-7d-cloudflare-validation.yml
@@ -1,0 +1,84 @@
+name: "Phase 7d: Cloudflare Tunnel Validation (P1 #351)"
+
+on:
+  push:
+    branches: [ main, feat/p1-351-cloudflare-tunnel-setup ]
+    paths:
+      - 'scripts/setup-cloudflare-tunnel.sh'
+      - '.github/workflows/phase-7d-cloudflare-validation.yml'
+      - 'terraform/modules/dns/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'scripts/setup-cloudflare-tunnel.sh'
+      - '.github/workflows/phase-7d-cloudflare-validation.yml'
+      - 'terraform/modules/dns/**'
+
+jobs:
+  validate-scripts:
+    name: "Validate Setup Scripts"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      
+      - name: "Lint bash scripts"
+        run: |
+          shellcheck scripts/setup-cloudflare-tunnel.sh
+
+  validate-terraform:
+    name: "Validate Terraform Config"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      
+      - name: "Setup Terraform"
+        uses: hashicorp/setup-terraform@a1502cd9e00b7433544849c73f357aa33bc23a12 # v3.1.0
+      
+      - name: "Terraform Init & Validate"
+        run: |
+          cd terraform/modules/dns
+          terraform init -backend=false
+          terraform validate
+
+  security-scan:
+    name: "Security Analysis"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      
+      - name: "Checkov analysis"
+        uses: bridgecrewio/checkov-action@994539659a8508e75eace23485d45d3c8c728362 # v12.2858.0
+        with:
+          directory: terraform/modules/dns
+          quiet: true
+          framework: terraform
+          soft_fail: true
+
+  on-prem-check:
+    name: "On-Prem Connectivity & Binary Check"
+    runs-on: self-hosted
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      
+      - name: "Validate cloudflared binary installation"
+        run: |
+          if ! command -v cloudflared &> /dev/null; then
+             echo "❌ cloudflared binary not found on on-prem host"
+             exit 1
+          fi
+          cloudflared --version
+
+      - name: "Check systemd service status"
+        run: |
+          if systemctl is-active --quiet cloudflared; then
+            echo "✅ cloudflared service is ACTIVE"
+          else
+            echo "⚠️ cloudflared service is INACTIVE or NOT FOUND"
+            # This is non-blocking until Phase 7d is fully merged and active
+            exit 0
+          fi

--- a/docs/CLOUDFLARE-TUNNEL-SETUP.md
+++ b/docs/CLOUDFLARE-TUNNEL-SETUP.md
@@ -1,0 +1,81 @@
+# Cloudflare Tunnel Setup (P1 #351)
+
+This document provides instructions for setting up and managing a Cloudflare Tunnel for secure, on-premises connectivity to `ide.kushnir.cloud`.
+
+---
+
+## Architecture Overview
+
+- **Hostname**: `ide.kushnir.cloud`
+- **Internal Host**: `192.168.168.31`
+- **Internal Service**: `http://caddy:80`
+- **Tunnel Service**: `cloudflared` (Systemd)
+
+---
+
+## 1. Prerequisites
+
+- ✅ Cloudflare account with a valid zone for `kushnir.cloud`.
+- ✅ Cloudflare API Token (Zone:Edit, DNS:Edit permissions).
+- ✅ Cloudflare Account ID and Zone ID.
+- ✅ Terraform installed (local or on-prem).
+- ✅ `CLOUDFLARE_TUNNEL_TOKEN` stored in a secure location (Vault or GitHub Secrets).
+
+---
+
+## 2. Infrastructure Setup (Terraform)
+
+Infrastructure is managed via Terraform in `terraform/modules/dns/main.tf`.
+
+To provision the tunnel and DNS records:
+```bash
+cd terraform
+# Ensure vars are set in terraform.tfvars or as ENV variables
+terraform plan
+terraform apply -auto-approve
+```
+
+---
+
+## 3. On-Prem Implementation
+
+Run the setup script on the primary host (`192.168.168.31`):
+
+```bash
+# SSH to the host
+ssh akushnir@192.168.168.31
+
+# Run the setup script (ensure token is set)
+export CLOUDFLARE_TUNNEL_TOKEN="your-token-here"
+sudo bash scripts/setup-cloudflare-tunnel.sh
+```
+
+---
+
+## 4. Monitoring & Health Checks
+
+- **Prometheus Metrics**: `localhost:7878/metrics` relative to the `cloudflared` service.
+- **Log Location**: `journalctl -u cloudflared`
+- **Status Dashboard**: [Zero Trust Dashboard](https://one.dash.cloudflare.com/) -> Access -> Tunnels
+
+---
+
+## 5. Troubleshooting & Rollback
+
+### Common Issues
+- **Authentication**: Ensure the `CLOUDFLARE_TUNNEL_TOKEN` is correct.
+- **Connectivity**: Verify outgoing HTTPS access patterns (TCP port 443, 7878).
+- **DNS**: Confirm the CNAME record points to `<tunnel-id>.cfargotunnel.com`.
+
+### Rollback (Manual)
+If the tunnel fails and you need to restore direct access:
+1. Update DNS record in Cloudflare or via Terraform to point directly to the host IP.
+2. Disable the `cloudflared` service:
+   ```bash
+   sudo systemctl stop cloudflared
+   sudo systemctl disable cloudflared
+   ```
+
+---
+
+**Last Updated**: April 16, 2026 | **Owner**: Alex Kushnir | **Reference**: #351

--- a/scripts/setup-cloudflare-tunnel.sh
+++ b/scripts/setup-cloudflare-tunnel.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Phase 7d-001: Cloudflare Tunnel Setup Script (P1 #351)
+# Implements installation and service management for cloudflared on-prem.
+
+set -e
+
+# Configuration (Overridable via ENV)
+CLOUDFLARE_TUNNEL_TOKEN="${CLOUDFLARE_TUNNEL_TOKEN:-}"
+TUNNEL_USER="cloudflare-tunnel"
+CLOUDFLARED_VERSION="latest"
+
+if [ -z "$CLOUDFLARE_TUNNEL_TOKEN" ]; then
+    echo "❌ ERROR: CLOUDFLARE_TUNNEL_TOKEN is not set."
+    exit 1
+fi
+
+echo "🚀 Starting Cloudflare Tunnel Setup..."
+
+# 1. Install cloudflared
+if ! command -v cloudflared &> /dev/null; then
+    echo "📦 Downloading cloudflared..."
+    # Using the official Linux amd64 binary (debian-based check)
+    if [ -f /etc/debian_version ]; then
+        curl -L --output cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb
+        sudo dpkg -i cloudflared.deb
+        rm cloudflared.deb
+    else
+        # Generic binary install
+        curl -L --output cloudflared https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64
+        chmod +x cloudflared
+        sudo mv cloudflared /usr/local/bin/
+    fi
+else
+    echo "✅ cloudflared is already installed: $(cloudflared --version)"
+fi
+
+# 2. Create service user if it doesn't exist
+if ! id "$TUNNEL_USER" &>/dev/null; then
+    echo "👤 Creating service user: $TUNNEL_USER"
+    sudo useradd -r -s /usr/sbin/nologin "$TUNNEL_USER"
+fi
+
+# 3. Create systemd service
+echo "🏗️ Configuring systemd service..."
+cat <<EOF | sudo tee /etc/systemd/system/cloudflared.service
+[Unit]
+Description=Cloudflare Tunnel (P1 #351)
+After=network.target
+StartLimitInterval=0
+StartLimitBurst=0
+
+[Service]
+Type=simple
+User=$TUNNEL_USER
+ExecStart=/usr/local/bin/cloudflared tunnel run --token $CLOUDFLARE_TUNNEL_TOKEN
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=cloudflared
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# 4. Reload and start
+echo "🔄 Reloading systemd and starting tunnel..."
+sudo systemctl daemon-reload
+sudo systemctl enable cloudflared
+sudo systemctl restart cloudflared
+
+echo "✨ Cloudflare Tunnel setup complete. Checking status..."
+sudo systemctl status cloudflared --no-pager | grep "Active:"


### PR DESCRIPTION
## Summary
Implementing Cloudflare Tunnel for secure, on-premises connectivity to the ide.kushnir.cloud environment. This fulfills Phase 7d-001 and high-priority issue #351.

## Changes
- scripts/setup-cloudflare-tunnel.sh: Automated on-prem installation and systemd service management for cloudflared.
- docs/CLOUDFLARE-TUNNEL-SETUP.md: Runbook and operational guide for the tunnel.
- .github/workflows/phase-7d-cloudflare-validation.yml: New CI/CD workflow for script linting and Terraform validation.
- Infrastructure (Terraform) is already present in 	erraform/modules/dns and is validated by the new CI gate.

## Deployment Strategy
1. **Script Validation**: Merge this PR to main (CI ensures scripts and TF are valid).
2. **Infrastructure**: Provision tunnel using Terraform on the primary host (192.168.168.31).
3. **On-Prem Service**: Run the setup script with the generated CLOUDFLARE_TUNNEL_TOKEN.
4. **Validation**: Confirm tunnel status in the Zero Trust dashboard and observability metrics.

## Rollback
1. Revert DNS record change (CNAME -> A/IP).
2. sudo systemctl stop cloudflared on the host.

Fixes #351