### PR TITLE
feat(auth): multi-tab session sync with broadcast channel (P2 #334)

### DIFF
--- a/frontend/src/utils/__tests__/session-sync.test.ts
+++ b/frontend/src/utils/__tests__/session-sync.test.ts
@@ -1,0 +1,76 @@
+/**
+ * session-sync.test.ts
+ * Unit tests for multi-tab session synchronization
+ */
+
+import { initSessionSync, broadcastSessionRefresh, acquireRefreshLock, releaseRefreshLock } from '../session-sync';
+
+// Mock BroadcastChannel
+class MockBroadcastChannel {
+  name: string;
+  onmessage: ((event: MessageEvent<any>) => void) | null = null;
+  postMessage: jest.Mock;
+
+  constructor(name: string) {
+    this.name = name;
+    this.postMessage = jest.fn((data) => {
+      // Simulate own tab receiving own message if we don't filter it
+      if (this.onmessage) {
+        this.onmessage({ data } as MessageEvent);
+      }
+    });
+  }
+}
+
+global.BroadcastChannel = MockBroadcastChannel as any;
+
+describe('Session Sync', () => {
+  let localStorageMock: Record<string, string> = {};
+
+  beforeEach(() => {
+    // Mock localStorage
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key: string) => localStorageMock[key] || null,
+        setItem: (key: string, val: string) => { localStorageMock[key] = val; },
+        removeItem: (key: string) => { delete localStorageMock[key]; },
+        clear: () => { localStorageMock = {}; },
+      },
+      writable: true,
+      configurable: true,
+    });
+    
+    // Clear state
+    localStorageMock = {};
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('acquireRefreshLock() succeeds when no lock is present', () => {
+    expect(acquireRefreshLock()).toBe(true);
+  });
+
+  test('acquireRefreshLock() fails when recent lock by another tab exists', () => {
+    const anotherTab = JSON.stringify({ ts: Date.now() - 1000, tabId: 'other-tab-id' });
+    localStorage.setItem('session_refresh_lock', anotherTab);
+    
+    expect(acquireRefreshLock()).toBe(false);
+  });
+
+  test('acquireRefreshLock() succeeds when old (expired) lock exists', () => {
+    const expiredLock = JSON.stringify({ ts: Date.now() - 20000, tabId: 'other-tab-id' });
+    localStorage.setItem('session_refresh_lock', expiredLock);
+    
+    expect(acquireRefreshLock()).toBe(true);
+  });
+
+  test('releaseRefreshLock() clears the lock', () => {
+    acquireRefreshLock();
+    expect(localStorage.getItem('session_refresh_lock')).not.toBeNull();
+    
+    releaseRefreshLock();
+    expect(localStorage.getItem('session_refresh_lock')).toBeNull();
+  });
+});

--- a/frontend/src/utils/session-sync.ts
+++ b/frontend/src/utils/session-sync.ts
@@ -1,0 +1,110 @@
+/**
+ * session-sync.ts
+ * Multi-tab session synchronization using BroadcastChannel
+ * Part of Phase 2 Session Self-Healing (#334)
+ */
+
+import { getSessionExpiry, scheduleRefresh } from './session-keepalive';
+
+const SESSION_CHANNEL_NAME = 'code-server-session';
+const LOCK_KEY = 'session_refresh_lock';
+const LOCK_TTL_MS = 10000; // 10s protection against thundering herd
+
+type SessionMessage =
+  | { type: 'SESSION_REFRESHED'; expiry: number; tabId: string }
+  | { type: 'SESSION_QUERY'; tabId: string }
+  | { type: 'SESSION_STATE'; expiry: number; tabId: string };
+
+const myTabId = typeof crypto !== 'undefined' ? crypto.randomUUID() : Math.random().toString(36).substring(7);
+let sessionChannel: BroadcastChannel | null = null;
+
+/**
+ * Initializes synchronization across multiple browser tabs
+ */
+export function initSessionSync(): void {
+  if (typeof window === 'undefined' || typeof BroadcastChannel === 'undefined') {
+    console.debug('[Session-Sync] BroadcastChannel not supported; falling back to independent refresh');
+    return;
+  }
+
+  sessionChannel = new BroadcastChannel(SESSION_CHANNEL_NAME);
+
+  sessionChannel.onmessage = (event: MessageEvent<SessionMessage>) => {
+    const msg = event.data;
+    if (msg.tabId === myTabId) return;
+
+    switch (msg.type) {
+      case 'SESSION_REFRESHED':
+      case 'SESSION_STATE':
+        console.debug(`[Session-Sync] Received updated session expiry (${msg.type}) from Tab ${msg.tabId}`);
+        // Cookie updated by server response (same domain), we just need to re-arm the local timer
+        scheduleRefresh(); 
+        break;
+      
+      case 'SESSION_QUERY':
+        console.debug(`[Session-Sync] Tab ${msg.tabId} queried for current session state`);
+        const exp = getSessionExpiry();
+        if (exp && sessionChannel) {
+          sessionChannel.postMessage({
+            type: 'SESSION_STATE',
+            expiry: exp,
+            tabId: myTabId
+          });
+        }
+        break;
+    }
+  };
+
+  // Query existing tabs to see if anyone has a recent expiry
+  sessionChannel.postMessage({ type: 'SESSION_QUERY', tabId: myTabId });
+}
+
+/**
+ * Broadcasts to all other tabs that we successfully refreshed the session
+ */
+export function broadcastSessionRefresh(newExpiry: number): void {
+  if (sessionChannel) {
+    sessionChannel.postMessage({
+      type: 'SESSION_REFRESHED',
+      expiry: newExpiry,
+      tabId: myTabId
+    });
+  }
+}
+
+/**
+ * Attempts to acquire a lock to perform a refresh
+ * Prevents multiple tabs from racing to the refresh endpoint simultaneously
+ */
+export function acquireRefreshLock(): boolean {
+  if (typeof localStorage === 'undefined') return true; // Fail-open to avoid stuck sessions
+
+  const now = Date.now();
+  const existing = localStorage.getItem(LOCK_KEY);
+  
+  if (existing) {
+    try {
+      const { ts, tabId } = JSON.parse(existing);
+      // If lock was acquired recently by another tab, return false
+      if (now - ts < LOCK_TTL_MS && tabId !== myTabId) {
+        console.debug(`[Session-Sync] Lock held by Tab ${tabId}, avoiding race condition`);
+        return false;
+      }
+    } catch (e) {
+      // Corrupt data, clear it
+      localStorage.removeItem(LOCK_KEY);
+    }
+  }
+
+  localStorage.setItem(LOCK_KEY, JSON.stringify({ ts: now, tabId: myTabId }));
+  return true;
+}
+
+/**
+ * Release the refresh lock after operation
+ */
+export function releaseRefreshLock(): void {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.removeItem(LOCK_KEY);
+  }
+}


### PR DESCRIPTION
## Summary
Implements the multi-tab synchronization layer for session self-healing.

## Changes
- **BroadcastChannel**: Real-time communication between browser tabs whenever any tab refreshes the session.
- **Leader Election**: Logic to ensure only one tab attempts to refresh the session at a time, preventing redundant server load.
- **State Querying**: New tabs automatically query existing tabs for current session state to avoid unnecessary initial network calls.
- **Tests**: Unit tests for lock acquisition, thundering herd prevention, and lock release.

## Why
Users frequently work across multiple IDE, terminal, and monitoring tabs. Without this sync layer, each tab would attempt to refresh independently, potentially leading to race conditions and "thundering herd" load on the authentication providers.

Fixes #334