### PR TITLE
fix(docker): OCI image labels + MANIFEST dockerfile registry (#304)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
+# @file        Dockerfile
+# @description CI pre-commit runner — linting, shellcheck, and governance hooks
+# @module      ci-runner
+
 FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.title="code-server-enterprise-ci-runner"
+LABEL org.opencontainers.image.description="CI pre-commit runner for linting, shellcheck, and governance hooks"
+LABEL org.opencontainers.image.source="https://github.com/kushin77/code-server"
+LABEL org.opencontainers.image.licenses="MIT"
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.caddy
+++ b/Dockerfile.caddy
@@ -1,5 +1,14 @@
+# @file        Dockerfile.caddy
+# @description Caddy v2 reverse proxy and TLS termination for on-prem code-server
+# @module      proxy
+
 # Official Caddy v2.9.1 reverse proxy and TLS termination
 # Simplified from xcaddy build (custom plugin compatibility issues)
 # Pinned to v2.9.1 for immutability and reproducible builds
 # Uses standard HTTP-01 Let's Encrypt challenge
 FROM caddy:2.9.1
+
+LABEL org.opencontainers.image.title="code-server-enterprise-caddy"
+LABEL org.opencontainers.image.description="Caddy v2 reverse proxy and TLS termination for on-prem code-server stack"
+LABEL org.opencontainers.image.source="https://github.com/kushin77/code-server"
+LABEL org.opencontainers.image.licenses="MIT"

--- a/Dockerfile.code-server
+++ b/Dockerfile.code-server
@@ -2,10 +2,19 @@
 # code-server enterprise build — IaC, immutable, idempotent
 # Pin all versions for reproducible builds and true immutability
 # ════════════════════════════════════════════════════════════════════════════
+# @file        Dockerfile.code-server
+# @description Production VS Code server (code-server) with Copilot extensions and auth patches
+# @module      ide
 
 ARG CODE_SERVER_VERSION=4.115.0
 
 FROM codercom/code-server:${CODE_SERVER_VERSION}
+
+# OCI image metadata (org.opencontainers.image spec)
+LABEL org.opencontainers.image.title="code-server-enterprise"
+LABEL org.opencontainers.image.description="Production VS Code server with Copilot extensions, oauth2 session patches, and enterprise auth"
+LABEL org.opencontainers.image.source="https://github.com/kushin77/code-server"
+LABEL org.opencontainers.image.licenses="MIT"
 
 # Version pinning for all extensions — set at build time, baked into image
 ARG COPILOT_VERSION=1.299.0

--- a/Dockerfile.ssh-proxy
+++ b/Dockerfile.ssh-proxy
@@ -5,10 +5,10 @@
 
 FROM python:3.11-slim
 
-LABEL maintainer="Code-Server Enterprise <ops@code-server.local>"
-LABEL description="SSH Proxy with Comprehensive Audit Logging"
-LABEL version="1.0.0"
-LABEL iac.version.python="3.11-slim"
+LABEL org.opencontainers.image.title="code-server-enterprise-ssh-proxy"
+LABEL org.opencontainers.image.description="SSH Proxy with comprehensive audit logging for on-prem code-server"
+LABEL org.opencontainers.image.source="https://github.com/kushin77/code-server"
+LABEL org.opencontainers.image.licenses="MIT"
 LABEL iac.immutable="true"
 LABEL iac.idempotent="true"
 

--- a/Dockerfile.token-microservice
+++ b/Dockerfile.token-microservice
@@ -3,10 +3,11 @@
 
 FROM python:3.11-slim
 
-# Labels
-LABEL maintainer="kushnir77"
-LABEL description="JWT Token Microservice for service-to-service authentication"
-LABEL version="1.0.0"
+# OCI labels
+LABEL org.opencontainers.image.title="code-server-enterprise-token-microservice"
+LABEL org.opencontainers.image.description="JWT Token Microservice for service-to-service authentication"
+LABEL org.opencontainers.image.source="https://github.com/kushin77/code-server"
+LABEL org.opencontainers.image.licenses="MIT"
 
 # Security: run as non-root
 RUN useradd -m -u 1000 tokenservice

--- a/scripts/MANIFEST.toml
+++ b/scripts/MANIFEST.toml
@@ -458,3 +458,42 @@ category = "operations"
 status   = "active"
 purpose  = "Test VPN endpoint connectivity and service health"
 
+# ════════════════════════════════════════════════════════════════════════════
+# Dockerfile Registry — OCI image build targets
+# ════════════════════════════════════════════════════════════════════════════
+
+[[dockerfile]]
+file        = "Dockerfile"
+category    = "ci-runner"
+status      = "active"
+base        = "ubuntu:22.04"
+purpose     = "CI pre-commit runner for linting, shellcheck, and governance hooks"
+
+[[dockerfile]]
+file        = "Dockerfile.caddy"
+category    = "proxy"
+status      = "active"
+base        = "caddy:2.9.1"
+purpose     = "Caddy v2 reverse proxy and TLS termination for on-prem stack"
+
+[[dockerfile]]
+file        = "Dockerfile.code-server"
+category    = "ide"
+status      = "active"
+base        = "codercom/code-server:${CODE_SERVER_VERSION}"
+purpose     = "Production VS Code server with Copilot extensions and enterprise auth patches"
+
+[[dockerfile]]
+file        = "Dockerfile.ssh-proxy"
+category    = "proxy"
+status      = "active"
+base        = "python:3.11-slim"
+purpose     = "SSH proxy service with comprehensive audit logging"
+
+[[dockerfile]]
+file        = "Dockerfile.token-microservice"
+category    = "auth"
+status      = "active"
+base        = "python:3.11-slim"
+purpose     = "JWT token microservice for service-to-service authentication (P1 #388 Phase 2)"
+


### PR DESCRIPTION
## Summary
Implements #304 (GOV-009): Dockerfile audit with OCI labels and MANIFEST registry.

## Changes

### OCI Labels Added to All 5 Dockerfiles
- \Dockerfile\ — CI pre-commit runner (ubuntu:22.04)
- \Dockerfile.caddy\ — Caddy reverse proxy (caddy:2.9.1)
- \Dockerfile.code-server\ — Production IDE (codercom/code-server)
- \Dockerfile.ssh-proxy\ — SSH proxy (migrated from custom to OCI spec)
- \Dockerfile.token-microservice\ — JWT microservice (migrated to OCI spec)

### Metadata Headers
Added \@file\/\@description\/\@module\ headers per GOV-002 standard.

### MANIFEST.toml
Added \[[dockerfile]]\ registry section with 5 entries (file, category, base, status, purpose).

## Notes
- hadolint lint job already exists in ci-validate.yml — no CI changes needed
- Version ARG duplication (CODE_SERVER_VERSION across compose/Dockerfile) tracked as tech debt — single-SSOT refactor is a separate concern from label addition

## Acceptance Criteria
- [x] All Dockerfiles audited with documented purpose
- [x] All Dockerfiles have OCI image labels
- [x] Dockerfile roles registered in MANIFEST.toml
- [x] hadolint gate enforced in CI (pre-existing)

Fixes #304