### PR TITLE
feat(telemetry): structured JSON logging + PII scrubbing + Loki dashboard (#395)

### DIFF
--- a/backend/src/lib/__tests__/logger.test.ts
+++ b/backend/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,271 @@
+// @file        backend/src/lib/__tests__/logger.test.ts
+// @module      observability
+// @description Unit tests for structured logger — PII scrubbing, error fingerprinting,
+//              log level filtering, child loggers, and request logging middleware.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StructuredLogger, fingerprintError, getLogger } from '../logger';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function captureStdout(fn: () => void): LogEntry[] {
+  const lines: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+    lines.push(String(chunk).trim());
+    return true;
+  });
+  fn();
+  process.stdout.write = originalWrite;
+  return lines.filter(Boolean).map((l) => JSON.parse(l) as LogEntry);
+}
+
+function captureStderr(fn: () => void): LogEntry[] {
+  const lines: string[] = [];
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+    lines.push(String(chunk).trim());
+    return true;
+  });
+  fn();
+  process.stderr.write = originalWrite;
+  return lines.filter(Boolean).map((l) => JSON.parse(l) as LogEntry);
+}
+
+interface LogEntry {
+  timestamp: string;
+  level: string;
+  message: string;
+  service: string;
+  [key: string]: unknown;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('StructuredLogger', () => {
+  let logger: StructuredLogger;
+
+  beforeEach(() => {
+    logger = new StructuredLogger('test-service', {}, 'debug');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('basic logging', () => {
+    it('emits valid JSON on info', () => {
+      const entries = captureStdout(() => logger.info('hello world'));
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        level: 'info',
+        message: 'hello world',
+        service: 'test-service',
+      });
+    });
+
+    it('includes ISO timestamp', () => {
+      const entries = captureStdout(() => logger.info('ts test'));
+      expect(entries[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('emits debug to stdout', () => {
+      const entries = captureStdout(() => logger.debug('debug msg'));
+      expect(entries[0].level).toBe('debug');
+    });
+
+    it('emits error to stderr', () => {
+      const entries = captureStderr(() => logger.error('error msg'));
+      expect(entries[0].level).toBe('error');
+    });
+
+    it('emits warn to stderr', () => {
+      const entries = captureStderr(() => logger.warn('warn msg'));
+      expect(entries[0].level).toBe('warn');
+    });
+  });
+
+  describe('log level filtering', () => {
+    it('filters debug when minLevel=info', () => {
+      const infoLogger = new StructuredLogger('svc', {}, 'info');
+      const entries = captureStdout(() => infoLogger.debug('filtered'));
+      expect(entries).toHaveLength(0);
+    });
+
+    it('passes info when minLevel=info', () => {
+      const infoLogger = new StructuredLogger('svc', {}, 'info');
+      const entries = captureStdout(() => infoLogger.info('passes'));
+      expect(entries).toHaveLength(1);
+    });
+
+    it('filters info when minLevel=error', () => {
+      const errLogger = new StructuredLogger('svc', {}, 'error');
+      const entries = captureStdout(() => errLogger.info('filtered'));
+      expect(entries).toHaveLength(0);
+    });
+  });
+
+  describe('child logger', () => {
+    it('inherits parent service name', () => {
+      const child = logger.child({ requestId: 'req-123' });
+      const entries = captureStdout(() => child.info('from child'));
+      expect(entries[0].service).toBe('test-service');
+      expect(entries[0].requestId).toBe('req-123');
+    });
+
+    it('merges additional context', () => {
+      const child1 = logger.child({ traceId: 'trace-1' });
+      const child2 = child1.child({ spanId: 'span-1' });
+      const entries = captureStdout(() => child2.info('nested'));
+      expect(entries[0].traceId).toBe('trace-1');
+      expect(entries[0].spanId).toBe('span-1');
+    });
+
+    it('does not pollute parent context', () => {
+      const child = logger.child({ userId: 'user-1' });
+      const parentEntries = captureStdout(() => logger.info('parent'));
+      expect(parentEntries[0].userId).toBeUndefined();
+    });
+  });
+
+  describe('PII scrubbing', () => {
+    it('redacts password fields', () => {
+      const entries = captureStdout(() =>
+        logger.info('login', { password: 'super-secret' }),
+      );
+      expect(entries[0].password).toBe('[REDACTED]');
+    });
+
+    it('redacts token fields', () => {
+      const entries = captureStdout(() =>
+        logger.info('request', { token: 'abc123' }),
+      );
+      expect(entries[0].token).toBe('[REDACTED]');
+    });
+
+    it('redacts nested secret fields', () => {
+      const entries = captureStdout(() =>
+        logger.info('config', { db: { password: 'db-pass' } }),
+      );
+      expect((entries[0].db as Record<string, unknown>)?.password).toBe('[REDACTED]');
+    });
+
+    it('redacts bearer tokens in string values', () => {
+      const entries = captureStdout(() =>
+        logger.info('auth', { header: 'Bearer eyJhbGc.eyJzdWI.SflKx' }),
+      );
+      expect(entries[0].header).toBe('Bearer [REDACTED]');
+    });
+
+    it('redacts email addresses', () => {
+      const entries = captureStdout(() =>
+        logger.info('user', { contact: 'user@example.com' }),
+      );
+      expect(entries[0].contact).toBe('[EMAIL-REDACTED]');
+    });
+
+    it('preserves non-PII fields', () => {
+      const entries = captureStdout(() =>
+        logger.info('request', { method: 'GET', statusCode: 200 }),
+      );
+      expect(entries[0].method).toBe('GET');
+      expect(entries[0].statusCode).toBe(200);
+    });
+
+    it('does not modify message text (message is not a field name)', () => {
+      const entries = captureStdout(() =>
+        logger.info('token validated', {}),
+      );
+      expect(entries[0].message).toBe('token validated');
+    });
+  });
+
+  describe('error logging', () => {
+    it('includes error name and message', () => {
+      const err = new TypeError('something went wrong');
+      const entries = captureStderr(() => logger.error('caught error', err));
+      const errorField = entries[0].error as Record<string, unknown>;
+      expect(errorField.name).toBe('TypeError');
+      expect(errorField.message).toBe('something went wrong');
+    });
+
+    it('includes errorFingerprint', () => {
+      const err = new TypeError('something went wrong');
+      const entries = captureStderr(() => logger.error('caught error', err));
+      expect(entries[0].errorFingerprint).toBeTruthy();
+      expect(typeof entries[0].errorFingerprint).toBe('string');
+    });
+
+    it('handles non-Error thrown values', () => {
+      const entries = captureStderr(() => logger.error('non-error', 'raw string error'));
+      expect(entries[0].error).toBe('raw string error');
+      expect(entries[0].errorFingerprint).toBeTruthy();
+    });
+  });
+
+  describe('request logging', () => {
+    it('logs HTTP request with method, path, status', () => {
+      const entries = captureStdout(() =>
+        logger.request('GET', '/api/health', 200, 42),
+      );
+      const http = entries[0].http as Record<string, unknown>;
+      expect(http.method).toBe('GET');
+      expect(http.path).toBe('/api/health');
+      expect(http.statusCode).toBe(200);
+      expect(http.durationMs).toBe(42);
+    });
+
+    it('logs 4xx at warn level', () => {
+      const entries = captureStderr(() =>
+        logger.request('GET', '/api/missing', 404, 10),
+      );
+      expect(entries[0].level).toBe('warn');
+    });
+
+    it('logs 5xx at error level', () => {
+      const entries = captureStderr(() =>
+        logger.request('POST', '/api/fail', 500, 100),
+      );
+      expect(entries[0].level).toBe('error');
+    });
+  });
+});
+
+describe('fingerprintError', () => {
+  it('returns consistent fingerprint for same error type', () => {
+    const err1 = new TypeError('same message');
+    const err2 = new TypeError('same message');
+    expect(fingerprintError(err1)).toBe(fingerprintError(err2));
+  });
+
+  it('returns different fingerprint for different error types', () => {
+    const err1 = new TypeError('oops');
+    const err2 = new RangeError('oops');
+    expect(fingerprintError(err1)).not.toBe(fingerprintError(err2));
+  });
+
+  it('handles non-Error values', () => {
+    expect(fingerprintError('string error')).toBeTruthy();
+    expect(fingerprintError(null)).toBeTruthy();
+    expect(typeof fingerprintError(42)).toBe('string');
+  });
+
+  it('returns 8-char hex fingerprint', () => {
+    const fp = fingerprintError(new Error('test'));
+    expect(fp).toMatch(/^[0-9a-f]{8}$/);
+  });
+});
+
+describe('getLogger', () => {
+  it('returns same instance for same service name', () => {
+    const a = getLogger('my-service-unique-x9z');
+    const b = getLogger('my-service-unique-x9z');
+    expect(a).toBe(b);
+  });
+
+  it('returns different instances for different services', () => {
+    const a = getLogger('service-aaa');
+    const b = getLogger('service-bbb');
+    expect(a).not.toBe(b);
+  });
+});

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -1,0 +1,269 @@
+// @file        backend/src/lib/logger.ts
+// @module      observability
+// @description Structured JSON logger with correlation ID propagation, PII scrubbing,
+//              error fingerprinting, and Loki-compatible output for all services.
+// @owner       platform
+// @status      active
+
+import { createHash } from 'node:crypto';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogContext {
+  traceId?: string;
+  spanId?: string;
+  userId?: string;
+  requestId?: string;
+  service?: string;
+  [key: string]: unknown;
+}
+
+export interface LogEntry {
+  timestamp: string;
+  level: LogLevel;
+  message: string;
+  service: string;
+  traceId?: string;
+  spanId?: string;
+  requestId?: string;
+  userId?: string;
+  errorFingerprint?: string;
+  durationMs?: number;
+  [key: string]: unknown;
+}
+
+// ── PII scrubbing ─────────────────────────────────────────────────────────────
+
+/** Fields whose values are always redacted (case-insensitive key match). */
+const PII_FIELD_PATTERNS = [
+  /password/i,
+  /secret/i,
+  /token/i,
+  /auth/i,
+  /cookie/i,
+  /session/i,
+  /credential/i,
+  /private_?key/i,
+  /api_?key/i,
+  /bearer/i,
+];
+
+/** Inline patterns redacted from string values. */
+const PII_VALUE_PATTERNS = [
+  // JWT bearer tokens
+  { pattern: /Bearer\s+[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+/g, replacement: 'Bearer [REDACTED]' },
+  // Email addresses
+  { pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, replacement: '[EMAIL-REDACTED]' },
+  // IPv4 user addresses (not internal ranges)
+  { pattern: /\b(?!192\.168\.|10\.|172\.(1[6-9]|2\d|3[01])\.)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, replacement: '[IP-REDACTED]' },
+];
+
+function scrubPII(obj: unknown, depth = 0): unknown {
+  if (depth > 10) return obj; // prevent infinite recursion
+  if (obj === null || obj === undefined) return obj;
+
+  if (typeof obj === 'string') {
+    let v = obj;
+    for (const { pattern, replacement } of PII_VALUE_PATTERNS) {
+      v = v.replace(pattern, replacement);
+    }
+    return v;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => scrubPII(item, depth + 1));
+  }
+
+  if (typeof obj === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      if (PII_FIELD_PATTERNS.some((p) => p.test(key))) {
+        result[key] = '[REDACTED]';
+      } else {
+        result[key] = scrubPII(value, depth + 1);
+      }
+    }
+    return result;
+  }
+
+  return obj;
+}
+
+// ── Error fingerprinting ──────────────────────────────────────────────────────
+
+/**
+ * Creates a stable fingerprint for an error based on its type and normalized stack trace.
+ * Allows grouping of identical errors across instances and over time.
+ */
+export function fingerprintError(err: Error | unknown): string {
+  if (!(err instanceof Error)) {
+    return createHash('sha1').update(String(err)).digest('hex').slice(0, 8);
+  }
+
+  // Normalize stack: strip line numbers to group same-type errors regardless of version
+  const normalizedStack = (err.stack ?? err.message)
+    .replace(/:\d+:\d+/g, '') // strip line:col numbers
+    .replace(/\/[^\s]+\//g, '/') // strip full paths, keep filenames
+    .slice(0, 500);
+
+  const fingerprint = createHash('sha1')
+    .update(`${err.constructor.name}:${normalizedStack}`)
+    .digest('hex')
+    .slice(0, 8);
+
+  return fingerprint;
+}
+
+// ── Logger class ──────────────────────────────────────────────────────────────
+
+export class StructuredLogger {
+  private readonly service: string;
+  private readonly baseContext: LogContext;
+  private readonly minLevel: LogLevel;
+
+  private static readonly LEVEL_ORDER: Record<LogLevel, number> = {
+    debug: 0,
+    info: 1,
+    warn: 2,
+    error: 3,
+  };
+
+  constructor(service: string, context: LogContext = {}, minLevel: LogLevel = 'info') {
+    this.service = service;
+    this.baseContext = context;
+    this.minLevel = (process.env['LOG_LEVEL'] as LogLevel) ?? minLevel;
+  }
+
+  /** Create a child logger with additional context fields merged in. */
+  child(additionalContext: LogContext): StructuredLogger {
+    return new StructuredLogger(
+      this.service,
+      { ...this.baseContext, ...additionalContext },
+      this.minLevel,
+    );
+  }
+
+  debug(message: string, fields?: Record<string, unknown>): void {
+    this.write('debug', message, fields);
+  }
+
+  info(message: string, fields?: Record<string, unknown>): void {
+    this.write('info', message, fields);
+  }
+
+  warn(message: string, fields?: Record<string, unknown>): void {
+    this.write('warn', message, fields);
+  }
+
+  error(message: string, err?: Error | unknown, fields?: Record<string, unknown>): void {
+    const errorFields: Record<string, unknown> = {};
+    if (err instanceof Error) {
+      errorFields['error'] = {
+        name: err.name,
+        message: err.message,
+        stack: err.stack,
+      };
+      errorFields['errorFingerprint'] = fingerprintError(err);
+    } else if (err !== undefined) {
+      errorFields['error'] = String(err);
+      errorFields['errorFingerprint'] = fingerprintError(err);
+    }
+    this.write('error', message, { ...errorFields, ...fields });
+  }
+
+  /** Log a request with duration (intended for HTTP middleware). */
+  request(
+    method: string,
+    path: string,
+    statusCode: number,
+    durationMs: number,
+    fields?: Record<string, unknown>,
+  ): void {
+    const level: LogLevel = statusCode >= 500 ? 'error' : statusCode >= 400 ? 'warn' : 'info';
+    this.write(level, `${method} ${path} ${statusCode}`, {
+      http: { method, path, statusCode, durationMs },
+      durationMs,
+      ...fields,
+    });
+  }
+
+  private write(level: LogLevel, message: string, fields?: Record<string, unknown>): void {
+    if (StructuredLogger.LEVEL_ORDER[level] < StructuredLogger.LEVEL_ORDER[this.minLevel]) {
+      return;
+    }
+
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      level,
+      message,
+      service: this.service,
+      ...this.baseContext,
+      ...(fields ? (scrubPII(fields) as Record<string, unknown>) : {}),
+    };
+
+    // Output as newline-delimited JSON (Loki / Promtail compatible)
+    const line = JSON.stringify(entry);
+    if (level === 'error' || level === 'warn') {
+      process.stderr.write(line + '\n');
+    } else {
+      process.stdout.write(line + '\n');
+    }
+  }
+}
+
+// ── Express/Node HTTP middleware ──────────────────────────────────────────────
+
+/**
+ * Express-compatible logging middleware.
+ * Injects a request-scoped logger and logs completed requests.
+ *
+ * @example
+ * app.use(requestLogger(logger));
+ */
+export function requestLogger(logger: StructuredLogger) {
+  return function loggingMiddleware(
+    req: { method: string; path: string; headers: Record<string, string | string[] | undefined>; log?: StructuredLogger },
+    res: { statusCode: number; on: (event: string, cb: () => void) => void },
+    next: () => void,
+  ): void {
+    const start = Date.now();
+    const requestId = (req.headers['x-request-id'] as string) ?? crypto.randomUUID();
+    const traceId = (req.headers['x-trace-id'] as string) ?? crypto.randomUUID();
+
+    // Attach request-scoped child logger
+    req.log = logger.child({ requestId, traceId });
+
+    res.on('finish', () => {
+      logger.request(req.method, req.path, res.statusCode, Date.now() - start, {
+        requestId,
+        traceId,
+      });
+    });
+
+    next();
+  };
+}
+
+// ── Singleton factory ─────────────────────────────────────────────────────────
+
+const loggers = new Map<string, StructuredLogger>();
+
+/**
+ * Get or create a named service logger (singleton per service name).
+ *
+ * @example
+ * const log = getLogger('session-service');
+ * log.info('Session created', { sessionId });
+ */
+export function getLogger(service: string, context?: LogContext): StructuredLogger {
+  const existing = loggers.get(service);
+  if (existing) return existing;
+  const logger = new StructuredLogger(service, context);
+  loggers.set(service, logger);
+  return logger;
+}
+
+/** Default application logger. */
+export const logger = getLogger('code-server-enterprise');

--- a/config/grafana/dashboards/structured-logs-telemetry.json
+++ b/config/grafana/dashboards/structured-logs-telemetry.json
@@ -1,0 +1,214 @@
+{
+  "annotations": { "list": [] },
+  "description": "Structured logs — correlation IDs, error fingerprinting, PII-scrubbed stream (#395)",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Log Volume",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "description": "Log lines per minute by level across all services",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 1 }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "error" }, "properties": [{ "id": "color", "value": { "fixedColor": "#e02f44", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "warn" },  "properties": [{ "id": "color", "value": { "fixedColor": "#ff9900", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "info" },  "properties": [{ "id": "color", "value": { "fixedColor": "#73bf69", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 1 },
+      "id": 1,
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "expr": "sum by (level) (rate({container_name=~\"$service\"} | json | line_format \"{{.level}}\" [1m]))",
+          "legendFormat": "{{level}}"
+        }
+      ],
+      "title": "Log Volume by Level",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "description": "Error fingerprint frequency — group recurring errors",
+      "fieldConfig": {
+        "defaults": { "unit": "short" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "id": 2,
+      "options": {
+        "displayMode": "list",
+        "reduceOptions": { "calcs": ["sum"] },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "expr": "sum by (errorFingerprint) (count_over_time({container_name=~\"$service\"} | json | errorFingerprint != \"\" [$__range]))",
+          "legendFormat": "{{errorFingerprint}}"
+        }
+      ],
+      "title": "Error Fingerprints (Top Recurring)",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "description": "P95 request duration by service (requires structured HTTP logs)",
+      "fieldConfig": {
+        "defaults": { "unit": "ms", "decimals": 0 },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "id": 3,
+      "options": { "tooltip": { "mode": "single" } },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "expr": "quantile_over_time(0.95, {container_name=~\"$service\"} | json | durationMs != \"\" | unwrap durationMs [5m]) by (service)",
+          "legendFormat": "p95 {{service}}"
+        }
+      ],
+      "title": "p95 Request Duration by Service",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "id": 101,
+      "title": "Live Log Stream",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "description": "Live structured log stream with level filter and correlation ID drill-down",
+      "gridPos": { "h": 15, "w": 24, "x": 0, "y": 18 },
+      "id": 4,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "expr": "{container_name=~\"$service\"} |= \"$search\" | json | level=~\"$level\"",
+          "legendFormat": "",
+          "maxLines": 500
+        }
+      ],
+      "title": "Structured Log Stream",
+      "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "id": 102,
+      "title": "Error Investigation",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource}" },
+      "description": "All error-level log entries with error fingerprint and stack traces",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 34 },
+      "id": 5,
+      "options": {
+        "dedupStrategy": "signature",
+        "enableLogDetails": true,
+        "prettifyLogMessage": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource}" },
+          "expr": "{container_name=~\"$service\"} | json | level=\"error\"",
+          "legendFormat": "",
+          "maxLines": 200
+        }
+      ],
+      "title": "Errors (deduplicated by signature)",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["logs", "loki", "observability", "telemetry"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Loki", "value": "loki" },
+        "hide": 0,
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "type": "datasource"
+      },
+      {
+        "datasource": { "type": "loki", "uid": "${datasource}" },
+        "definition": "label_values(container_name)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "options": [],
+        "query": "label_values(container_name)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "selected": true, "text": "All", "value": ".*" },
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "level",
+        "options": [
+          { "selected": true, "text": "All",   "value": ".*" },
+          { "selected": false, "text": "debug", "value": "debug" },
+          { "selected": false, "text": "info",  "value": "info" },
+          { "selected": false, "text": "warn",  "value": "warn" },
+          { "selected": false, "text": "error", "value": "error" }
+        ],
+        "query": "debug,info,warn,error",
+        "type": "custom"
+      },
+      {
+        "current": { "text": "", "value": "" },
+        "hide": 0,
+        "name": "search",
+        "options": [{ "selected": true, "text": "", "value": "" }],
+        "query": "",
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Structured Logs — Telemetry (Phase 2)",
+  "uid": "structured-logs-phase2",
+  "version": 1
+}


### PR DESCRIPTION
## Summary
Implements #395 (Phase 2 Telemetry): structured logging with correlation IDs, PII scrubbing, error fingerprinting, and Grafana log dashboard.

## Changes

### \ackend/src/lib/logger.ts\ (new)
- \StructuredLogger\ — newline-delimited JSON, Loki compatible
- PII scrubbing: password/token/secret/cookie/credential fields + bearer tokens + emails
- Error fingerprinting: stable 8-char SHA1 hash for recurring error grouping
- Child loggers with merged context propagation
- LOG_LEVEL env var filtering
- \equestLogger()\ Express-compatible middleware
- \getLogger(service)\ singleton factory

### \ackend/src/lib/__tests__/logger.test.ts\ (new — 25+ tests)
- Level filtering, child context, PII scrubbing, error fingerprints, HTTP log levels

### \promtail-config.yml\ — defense-in-depth PII scrubbing pipeline stages
- JWT bearer tokens, JSON credential fields, email addresses redacted before Loki ingest

### \config/grafana/dashboards/structured-logs-telemetry.json\ (new)
- Log volume by level, error fingerprint frequency, p95 request duration
- Live log stream + error stream with signature deduplication
- TraceID → Jaeger drill-down via existing Loki datasource

Fixes #395