### PR TITLE
feat(ai): semantic chunking + incremental async indexing foundation (P2 #393)

### DIFF
--- a/backend/src/services/ai/__tests__/indexing.test.ts
+++ b/backend/src/services/ai/__tests__/indexing.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  RepositoryIndexer,
+  chunkByTokenWindow,
+  inferLanguage,
+  semanticBoundaries,
+} from "../indexing";
+
+describe("inferLanguage", () => {
+  it("detects supported languages", () => {
+    expect(inferLanguage("src/a.py")).toBe("python");
+    expect(inferLanguage("src/a.ts")).toBe("typescript");
+    expect(inferLanguage("src/a.go")).toBe("go");
+    expect(inferLanguage("src/a.rs")).toBe("rust");
+    expect(inferLanguage("src/A.java")).toBe("java");
+    expect(inferLanguage("README.md")).toBe("unknown");
+  });
+});
+
+describe("semanticBoundaries", () => {
+  it("extracts python class/function boundaries", () => {
+    const content = [
+      "class User:",
+      "  def __init__(self):",
+      "    pass",
+      "",
+      "def helper():",
+      "  return True",
+    ].join("\n");
+
+    const boundaries = semanticBoundaries(content, "python");
+    expect(boundaries.length).toBeGreaterThanOrEqual(2);
+    expect(boundaries[0].symbol).toBe("User");
+  });
+
+  it("falls back to single file boundary for unknown", () => {
+    const boundaries = semanticBoundaries("hello world", "unknown");
+    expect(boundaries).toHaveLength(1);
+    expect(boundaries[0].symbol).toBe("file");
+  });
+});
+
+describe("chunkByTokenWindow", () => {
+  it("applies overlap window", () => {
+    const content = "a b c d e f g h";
+    const chunks = chunkByTokenWindow(content, 4, 1);
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toBe("a b c d");
+    expect(chunks[1]).toBe("d e f g");
+  });
+});
+
+describe("RepositoryIndexer", () => {
+  it("indexes repository files into semantic chunks", async () => {
+    const indexer = new RepositoryIndexer({ chunkSizeTokens: 12, chunkOverlapTokens: 2 });
+
+    const result = await indexer.indexRepository([
+      {
+        path: "backend/src/foo.py",
+        content: [
+          "class Foo:",
+          "  def run(self):",
+          "    return 1",
+          "",
+          "def util(a, b):",
+          "  return a + b",
+        ].join("\n"),
+      },
+      {
+        path: "backend/src/bar.ts",
+        content: [
+          "export function sum(a:number,b:number){",
+          "  return a+b",
+          "}",
+        ].join("\n"),
+      },
+    ]);
+
+    expect(result.indexedFiles).toBe(2);
+    expect(result.indexedChunks).toBeGreaterThan(0);
+    expect(indexer.getAllChunks().length).toBe(result.indexedChunks);
+  });
+
+  it("does not reindex unchanged file", async () => {
+    const indexer = new RepositoryIndexer();
+    const file = {
+      path: "backend/src/sample.ts",
+      content: "export function a(){ return 1 }",
+    };
+
+    await indexer.indexRepository([file]);
+    const changed = await indexer.reindexChangedFile(file);
+    expect(changed).toBe(false);
+  });
+
+  it("reindexes changed file and keeps queue depth stable", async () => {
+    const indexer = new RepositoryIndexer();
+
+    await indexer.indexRepository([
+      { path: "backend/src/sample.ts", content: "export function a(){ return 1 }" },
+    ]);
+
+    const changed = await indexer.processFileChange(
+      "backend/src/sample.ts",
+      "export function a(){ return 2 }",
+    );
+
+    expect(changed).toBe(true);
+    expect(indexer.getQueueDepth()).toBe(0);
+  });
+
+  it("deduplicates identical chunk content across files", async () => {
+    const indexer = new RepositoryIndexer({ chunkSizeTokens: 20, chunkOverlapTokens: 0 });
+    const content = "export function shared(){ return 42 }";
+
+    await indexer.indexRepository([
+      { path: "a.ts", content },
+      { path: "b.ts", content },
+    ]);
+
+    expect(indexer.getAllChunks().length).toBe(1);
+  });
+
+  it("returns ranked keyword search results", async () => {
+    const indexer = new RepositoryIndexer();
+
+    await indexer.indexRepository([
+      { path: "a.ts", content: "function auth login token validate session" },
+      { path: "b.ts", content: "function math add subtract multiply divide" },
+    ]);
+
+    const results = indexer.search("auth token", 5);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].chunk.content).toContain("auth");
+  });
+
+  it("throws when queue is full", async () => {
+    const indexer = new RepositoryIndexer({ maxQueueSize: 0 });
+
+    await expect(
+      indexer.reindexChangedFile({ path: "a.ts", content: "function x(){}" }),
+    ).rejects.toThrow("Index queue is full");
+  });
+});

--- a/backend/src/services/ai/index.ts
+++ b/backend/src/services/ai/index.ts
@@ -1,2 +1,17 @@
 export { AIRouter } from "./router";
 export type { RouteRequest, RouteResult, ModelEntry } from "./router";
+export {
+	RepositoryIndexer,
+	inferLanguage,
+	semanticBoundaries,
+	chunkByTokenWindow,
+} from "./indexing";
+export type {
+	SupportedLanguage,
+	RepositoryFile,
+	RepositoryChunk,
+	ChunkMetadata,
+	IndexingOptions,
+	IndexingResult,
+	SearchResult,
+} from "./indexing";

--- a/backend/src/services/ai/indexing.ts
+++ b/backend/src/services/ai/indexing.ts
@@ -1,0 +1,341 @@
+// @file        backend/src/services/ai/indexing.ts
+// @module      ai
+// @description Semantic chunking + incremental async indexing pipeline for repository files.
+// @owner       platform
+// @status      active
+
+import { createHash } from "node:crypto";
+
+export type SupportedLanguage = "python" | "typescript" | "go" | "rust" | "java" | "unknown";
+
+export interface RepositoryFile {
+  path: string;
+  content: string;
+  updatedAt?: number;
+}
+
+export interface ChunkMetadata {
+  filePath: string;
+  language: SupportedLanguage;
+  symbol: string;
+  startLine: number;
+  endLine: number;
+  contentHash: string;
+}
+
+export interface RepositoryChunk {
+  id: string;
+  content: string;
+  tokenCount: number;
+  metadata: ChunkMetadata;
+}
+
+export interface IndexingOptions {
+  chunkSizeTokens: number;
+  chunkOverlapTokens: number;
+  maxQueueSize: number;
+}
+
+export interface IndexingResult {
+  indexedFiles: number;
+  indexedChunks: number;
+  deduplicatedChunks: number;
+  queueDepth: number;
+}
+
+export interface SearchResult {
+  chunk: RepositoryChunk;
+  score: number;
+}
+
+type QueueTask = () => Promise<void>;
+
+const DEFAULT_OPTIONS: IndexingOptions = {
+  chunkSizeTokens: 800,
+  chunkOverlapTokens: 120,
+  maxQueueSize: 1000,
+};
+
+interface SymbolBoundary {
+  symbol: string;
+  startLine: number;
+  endLine: number;
+}
+
+export class RepositoryIndexer {
+  private readonly options: IndexingOptions;
+  private readonly chunksById = new Map<string, RepositoryChunk>();
+  private readonly chunkHashToId = new Map<string, string>();
+  private readonly fileHash = new Map<string, string>();
+
+  private readonly queue: QueueTask[] = [];
+  private queueActive = false;
+
+  constructor(options?: Partial<IndexingOptions>) {
+    this.options = {
+      ...DEFAULT_OPTIONS,
+      ...options,
+    };
+  }
+
+  async indexRepository(files: RepositoryFile[]): Promise<IndexingResult> {
+    let indexedFiles = 0;
+
+    for (const file of files) {
+      await this.enqueue(async () => {
+        const changed = this.indexFileInternal(file);
+        if (changed) {
+          indexedFiles += 1;
+        }
+      });
+    }
+
+    return {
+      indexedFiles,
+      indexedChunks: this.chunksById.size,
+      deduplicatedChunks: this.chunkHashToId.size - this.chunksById.size,
+      queueDepth: this.queue.length,
+    };
+  }
+
+  async reindexChangedFile(file: RepositoryFile): Promise<boolean> {
+    let changed = false;
+
+    await this.enqueue(async () => {
+      changed = this.indexFileInternal(file);
+    });
+
+    return changed;
+  }
+
+  async processFileChange(path: string, content: string): Promise<boolean> {
+    return this.reindexChangedFile({ path, content, updatedAt: Date.now() });
+  }
+
+  getQueueDepth(): number {
+    return this.queue.length;
+  }
+
+  getAllChunks(): RepositoryChunk[] {
+    return Array.from(this.chunksById.values());
+  }
+
+  search(query: string, limit = 10): SearchResult[] {
+    const q = tokenize(query.toLowerCase());
+    if (q.length === 0) return [];
+
+    const scored = this.getAllChunks().map((chunk) => {
+      const hay = tokenize(chunk.content.toLowerCase());
+      const overlap = q.filter((term) => hay.includes(term)).length;
+      const score = overlap / q.length;
+      return { chunk, score };
+    });
+
+    return scored
+      .filter((s) => s.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+  }
+
+  private async enqueue(task: QueueTask): Promise<void> {
+    if (this.queue.length >= this.options.maxQueueSize) {
+      throw new Error(`Index queue is full (${this.options.maxQueueSize})`);
+    }
+
+    this.queue.push(task);
+    await this.drainQueue();
+  }
+
+  private async drainQueue(): Promise<void> {
+    if (this.queueActive) return;
+    this.queueActive = true;
+
+    try {
+      while (this.queue.length > 0) {
+        const task = this.queue.shift();
+        if (!task) continue;
+        await task();
+      }
+    } finally {
+      this.queueActive = false;
+    }
+  }
+
+  private indexFileInternal(file: RepositoryFile): boolean {
+    const language = inferLanguage(file.path);
+    const fileContentHash = hash(file.content);
+
+    if (this.fileHash.get(file.path) === fileContentHash) {
+      return false;
+    }
+
+    this.removeChunksForFile(file.path);
+
+    const boundaries = semanticBoundaries(file.content, language);
+    const created = this.buildChunks(file.path, file.content, language, boundaries);
+
+    for (const chunk of created) {
+      if (this.chunkHashToId.has(chunk.metadata.contentHash)) {
+        continue;
+      }
+      this.chunkHashToId.set(chunk.metadata.contentHash, chunk.id);
+      this.chunksById.set(chunk.id, chunk);
+    }
+
+    this.fileHash.set(file.path, fileContentHash);
+    return true;
+  }
+
+  private removeChunksForFile(filePath: string): void {
+    for (const [id, chunk] of this.chunksById.entries()) {
+      if (chunk.metadata.filePath === filePath) {
+        this.chunksById.delete(id);
+        this.chunkHashToId.delete(chunk.metadata.contentHash);
+      }
+    }
+  }
+
+  private buildChunks(
+    filePath: string,
+    content: string,
+    language: SupportedLanguage,
+    boundaries: SymbolBoundary[],
+  ): RepositoryChunk[] {
+    const lines = content.split(/\r?\n/);
+    const chunks: RepositoryChunk[] = [];
+
+    for (const boundary of boundaries) {
+      const raw = lines.slice(boundary.startLine - 1, boundary.endLine).join("\n");
+      const windows = chunkByTokenWindow(raw, this.options.chunkSizeTokens, this.options.chunkOverlapTokens);
+
+      let segment = 0;
+      for (const windowContent of windows) {
+        const tokenCount = estimateTokenCount(windowContent);
+        const contentHash = hash(windowContent);
+        const id = hash(`${filePath}:${boundary.symbol}:${segment}:${contentHash}`).slice(0, 16);
+
+        chunks.push({
+          id,
+          content: windowContent,
+          tokenCount,
+          metadata: {
+            filePath,
+            language,
+            symbol: boundary.symbol,
+            startLine: boundary.startLine,
+            endLine: boundary.endLine,
+            contentHash,
+          },
+        });
+        segment += 1;
+      }
+    }
+
+    return chunks;
+  }
+}
+
+export function inferLanguage(filePath: string): SupportedLanguage {
+  const lower = filePath.toLowerCase();
+  if (lower.endsWith(".py")) return "python";
+  if (lower.endsWith(".ts") || lower.endsWith(".tsx") || lower.endsWith(".js")) return "typescript";
+  if (lower.endsWith(".go")) return "go";
+  if (lower.endsWith(".rs")) return "rust";
+  if (lower.endsWith(".java")) return "java";
+  return "unknown";
+}
+
+export function semanticBoundaries(content: string, language: SupportedLanguage): SymbolBoundary[] {
+  const lines = content.split(/\r?\n/);
+  if (lines.length === 0) {
+    return [{ symbol: "file", startLine: 1, endLine: 1 }];
+  }
+
+  const starts = detectSymbolStarts(lines, language);
+  if (starts.length === 0) {
+    return [{ symbol: "file", startLine: 1, endLine: lines.length }];
+  }
+
+  const boundaries: SymbolBoundary[] = [];
+  for (let i = 0; i < starts.length; i += 1) {
+    const current = starts[i];
+    const next = starts[i + 1];
+    boundaries.push({
+      symbol: current.symbol,
+      startLine: current.line,
+      endLine: next ? Math.max(current.line, next.line - 1) : lines.length,
+    });
+  }
+
+  return boundaries;
+}
+
+function detectSymbolStarts(lines: string[], language: SupportedLanguage): Array<{ symbol: string; line: number }> {
+  const starts: Array<{ symbol: string; line: number }> = [];
+
+  const patternByLanguage: Record<SupportedLanguage, RegExp[]> = {
+    python: [/^\s*def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/, /^\s*class\s+([A-Za-z_][A-Za-z0-9_]*)\s*[:(]/],
+    typescript: [
+      /^\s*export\s+class\s+([A-Za-z_][A-Za-z0-9_]*)/,
+      /^\s*class\s+([A-Za-z_][A-Za-z0-9_]*)/,
+      /^\s*export\s+function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/,
+      /^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/,
+      /^\s*const\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*\(?.*=>/,
+    ],
+    go: [/^\s*func\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/, /^\s*type\s+([A-Za-z_][A-Za-z0-9_]*)\s+struct\s*\{/],
+    rust: [/^\s*fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/, /^\s*impl\s+([A-Za-z_][A-Za-z0-9_:<>]*)/],
+    java: [
+      /^\s*(public\s+)?class\s+([A-Za-z_][A-Za-z0-9_]*)/,
+      /^\s*(public|private|protected)?\s*(static\s+)?[A-Za-z0-9_<>,\[\]]+\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/,
+    ],
+    unknown: [],
+  };
+
+  const patterns = patternByLanguage[language] || [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    for (const pattern of patterns) {
+      const match = line.match(pattern);
+      if (!match) continue;
+      const name = (match[3] || match[2] || match[1] || "symbol").trim();
+      starts.push({ symbol: name, line: i + 1 });
+      break;
+    }
+  }
+
+  return starts;
+}
+
+export function chunkByTokenWindow(content: string, chunkSizeTokens: number, overlapTokens: number): string[] {
+  const words = tokenize(content);
+  if (words.length === 0) return [""];
+
+  const chunks: string[] = [];
+  let cursor = 0;
+  const step = Math.max(1, chunkSizeTokens - overlapTokens);
+
+  while (cursor < words.length) {
+    const end = Math.min(words.length, cursor + chunkSizeTokens);
+    const windowWords = words.slice(cursor, end);
+    chunks.push(windowWords.join(" "));
+    if (end === words.length) break;
+    cursor += step;
+  }
+
+  return chunks;
+}
+
+function estimateTokenCount(content: string): number {
+  return tokenize(content).length;
+}
+
+function tokenize(content: string): string[] {
+  return content
+    .split(/\s+/)
+    .map((x) => x.trim())
+    .filter((x) => x.length > 0);
+}
+
+function hash(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}


### PR DESCRIPTION
## Summary
Implements the foundational indexing pipeline improvements for #393: semantic chunking, incremental dedup/indexing primitives, and async queue-based ingestion.

## Changes
- add semantic boundary chunking for Python, TypeScript, Go, Rust, Java
- add queue-based async repository indexer with incremental dedup via content hashes
- add overlap windows and language-aware chunk extraction
- add ranking/search helper for indexed chunks
- add unit tests for chunking boundaries, dedup, overlap, queue behavior, and language detection

## Scope Note
This PR intentionally delivers the **foundation slice** of #393 without claiming full completion of all acceptance criteria (e.g., full quality dashboard and p95 latency benchmarking). Remaining work will continue under #393.

## Why
Moves indexing from shallow synchronous behavior toward scalable asynchronous chunked indexing while keeping change risk controlled.

Refs #393