### PR TITLE
fix(gov): enforce GOV-002 metadata via MANIFEST-scoped canonical checker (P2 #297)

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -190,32 +190,5 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - name: Check all active scripts have @file metadata headers
-        run: |
-          set -euo pipefail
-          missing=0
-          total=0
-          while IFS= read -r -d '' f; do
-            # Skip _common and _archive
-            [[ "$f" == */_common/* || "$f" == */_archive/* ]] && continue
-            total=$((total + 1))
-            if ! head -6 "$f" | grep -qE "^# @file"; then
-              echo "MISSING @file header: $f"
-              missing=$((missing + 1))
-            fi
-          done < <(find scripts/ -name "*.sh" -type f -print0 | sort -z)
-
-          echo ""
-          echo "Total scripts scanned: $total"
-          echo "Missing @file headers: $missing"
-
-          if [[ $missing -gt 0 ]]; then
-            echo ""
-            echo "::error::$missing script(s) missing @file metadata header (GOV-002 #297)"
-            echo "Run scripts/dev/add-metadata-headers.sh to fix, or add manually:"
-            echo "  # @file        scripts/<name>.sh"
-            echo "  # @module      <module>"
-            echo "  # @description <one-line description>"
-            exit 1
-          fi
-          echo "✅ All $total scripts have @file metadata headers"
+      - name: Check active scripts satisfy GOV-002 metadata policy
+        run: bash scripts/ci/check-metadata-headers.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,26 +24,8 @@ repos:
 
       # Phase 2.3: Custom hook - verify metadata headers (GOV-002 #297 — all active scripts)
       - id: verify-metadata-headers
-        name: Verify @file/@module/@description headers in ALL scripts
-        entry: bash -c '
-          # Check ALL staged scripts (not just new ones) — migration complete, enforce globally
-          staged=$(git diff --cached --name-only -- "scripts/*.sh" "scripts/**/*.sh" 2>/dev/null \
-            | grep -v "_common/" | grep -v "_archive/")
-          if [[ -n "$staged" ]]; then
-            missing_headers=0
-            for f in $staged; do
-              [[ -f "$f" ]] || continue
-              if ! head -6 "$f" | grep -qE "@file"; then
-                echo "ERROR: $f missing @file metadata header"
-                echo "  Add: # @file        $f"
-                echo "       # @module      <module>"
-                echo "       # @description <one-line description>"
-                missing_headers=$((missing_headers + 1))
-              fi
-            done
-            [[ $missing_headers -gt 0 ]] && exit 1
-          fi
-        '
+        name: Verify GOV-002 metadata on active scripts
+        entry: bash scripts/ci/check-metadata-headers.sh
         language: system
         files: '^scripts/.*\.sh$'
         pass_filenames: false

--- a/scripts/ci/check-metadata-headers.sh
+++ b/scripts/ci/check-metadata-headers.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# @file        scripts/ci/check-metadata-headers.sh
+# @module      governance
+# @description Enforce @file/@module/@description metadata on active MANIFEST scripts and cross-check MANIFEST purpose.
+# @owner       platform
+# @status      active
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="${REPO_ROOT}/scripts/MANIFEST.toml"
+
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "ERROR: MANIFEST not found: ${MANIFEST}"
+  exit 1
+fi
+
+normalize() {
+  tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9 ]+/ /g; s/[[:space:]]+/ /g; s/^ //; s/ $//'
+}
+
+failures=0
+total=0
+warnings=0
+
+while IFS=$'\t' read -r rel_path purpose; do
+  script_path="${REPO_ROOT}/scripts/${rel_path}"
+  total=$((total + 1))
+
+  if [[ ! -f "${script_path}" ]]; then
+    echo "ERROR: active MANIFEST script missing from disk: scripts/${rel_path}"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  header="$(head -12 "${script_path}")"
+
+  if ! grep -qE '^# @file[[:space:]]+scripts/' <<<"${header}"; then
+    echo "ERROR: missing @file header: scripts/${rel_path}"
+    failures=$((failures + 1))
+  fi
+
+  if ! grep -qE '^# @module[[:space:]]+[^[:space:]].*$' <<<"${header}"; then
+    echo "ERROR: missing @module header: scripts/${rel_path}"
+    failures=$((failures + 1))
+  fi
+
+  if ! grep -qE '^# @description[[:space:]]+[^[:space:]].*$' <<<"${header}"; then
+    echo "ERROR: missing @description header: scripts/${rel_path}"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if [[ -n "${purpose}" && "${purpose}" != "TODO: add purpose" ]]; then
+    manifest_norm="$(printf '%s' "${purpose}" | normalize)"
+    desc_line="$(grep -E '^# @description' <<<"${header}" | head -1 | sed -E 's/^# @description[[:space:]]+//')"
+    desc_norm="$(printf '%s' "${desc_line}" | normalize)"
+
+    if [[ "${desc_norm}" != *"${manifest_norm}"* ]]; then
+      echo "ERROR: purpose/header drift: scripts/${rel_path}"
+      echo "  MANIFEST purpose: ${purpose}"
+      echo "  Header desc:      ${desc_line}"
+      failures=$((failures + 1))
+    fi
+  else
+    warnings=$((warnings + 1))
+    echo "WARN: TODO purpose in MANIFEST (cross-ref skipped): scripts/${rel_path}"
+  fi
+done < <(
+  awk -F '"' '
+    BEGIN { in_script=0; file=""; status=""; purpose="" }
+    /^\[\[script\]\]/ { in_script=1; file=""; status=""; purpose=""; next }
+    /^\[\[/ && !/^\[\[script\]\]/ { in_script=0; next }
+    !in_script { next }
+    /^file[[:space:]]*=/ { file=$2; next }
+    /^status[[:space:]]*=/ { status=$2; next }
+    /^purpose[[:space:]]*=/ {
+      purpose=$2;
+      if (status=="active" && file!="") {
+        print file "\t" purpose;
+      }
+      next
+    }
+  ' "${MANIFEST}" | sort -u
+)
+
+echo ""
+echo "Metadata header audit complete"
+echo "Active scripts scanned: ${total}"
+echo "Warnings: ${warnings}"
+
+if [[ ${failures} -gt 0 ]]; then
+  echo "Failures: ${failures}"
+  exit 1
+fi
+
+echo "Failures: 0"
+echo "PASS: active scripts satisfy GOV-002 metadata header requirements"

--- a/scripts/configure-rbac-enforcement-phase3.sh
+++ b/scripts/configure-rbac-enforcement-phase3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # @file        scripts/configure-rbac-enforcement-phase3.sh
 # @module      iam
-# @description configure rbac enforcement phase3 — on-prem code-server
+# @description Generate RBAC enforcement configuration (Caddyfile JWT middleware, policies, audit logging).
 # @owner       platform
 # @status      active
 #############################################################################

--- a/scripts/dev/add-metadata-headers.sh
+++ b/scripts/dev/add-metadata-headers.sh
@@ -16,6 +16,7 @@ SCRIPTS_DIR="${REPO_ROOT}/scripts"
 DRY_RUN=false
 VERBOSE=false
 TARGET_DIR="${SCRIPTS_DIR}"
+ACTIVE_ONLY=false
 
 usage() {
   cat <<EOF
@@ -26,6 +27,7 @@ Adds @file/@module/@description metadata headers to bash scripts missing them.
 OPTIONS:
   --dry-run         Preview changes without modifying files
   --verbose         Print all files including already-compliant ones
+  --active-only     Only process scripts marked status="active" in scripts/MANIFEST.toml
   --dir PATH        Target directory (default: scripts/)
   --help            Show this help
 
@@ -41,6 +43,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)   DRY_RUN=true ;;
     --verbose)   VERBOSE=true ;;
+    --active-only) ACTIVE_ONLY=true ;;
     --dir)       TARGET_DIR="$2"; shift ;;
     --help|-h)   usage; exit 0 ;;
     *)           echo "Unknown option: $1"; usage; exit 1 ;;
@@ -88,7 +91,7 @@ derive_description() {
   local name
   name="$(basename "$file" .sh)"
   # Convert kebab-case to sentence
-  echo "${name//-/ }" | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); print}' | sed 's/$/ — on-prem code-server enterprise/'
+  echo "${name//-/ }" | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2); print}' | sed 's/$/ - on-prem code-server enterprise/'
 }
 
 # Add header to a single file
@@ -139,25 +142,64 @@ total=0
 skipped=0
 added=0
 
-echo "🔍 Scanning ${TARGET_DIR} for scripts missing @file headers..."
+if [[ "${ACTIVE_ONLY}" == "true" ]]; then
+  echo "🔍 Scanning active MANIFEST scripts for missing @file headers..."
+else
+  echo "🔍 Scanning ${TARGET_DIR} for scripts missing @file headers..."
+fi
 [[ "$DRY_RUN" == "true" ]] && echo "   Mode: DRY RUN — no files will be modified"
 echo ""
 
-while IFS= read -r -d '' file; do
-  # Skip _common and _archive directories
-  [[ "$file" == *"/_common/"* || "$file" == *"/_archive/"* ]] && continue
+if [[ "${ACTIVE_ONLY}" == "true" ]]; then
+  while IFS=$'\t' read -r rel status; do
+    [[ "${status}" == "active" ]] || continue
+    file="${REPO_ROOT}/scripts/${rel}"
 
-  total=$((total + 1))
+    total=$((total + 1))
 
-  if head -5 "$file" | grep -qE "@file"; then
-    skipped=$((skipped + 1))
-    [[ "$VERBOSE" == "true" ]] && echo "  ⏭️  Already has header: ${file#${REPO_ROOT}/}"
-    continue
-  fi
+    if [[ ! -f "${file}" ]]; then
+      echo "  ⚠️  Missing file from MANIFEST: scripts/${rel}"
+      continue
+    fi
 
-  add_header "$file"
-  added=$((added + 1))
-done < <(find "${TARGET_DIR}" -name "*.sh" -type f -print0 | sort -z)
+    if head -5 "$file" | grep -qE "@file"; then
+      skipped=$((skipped + 1))
+      [[ "$VERBOSE" == "true" ]] && echo "  ⏭️  Already has header: scripts/${rel}"
+      continue
+    fi
+
+    add_header "$file"
+    added=$((added + 1))
+  done < <(
+    awk -F '"' '
+      BEGIN { in_script=0; file=""; status="" }
+      /^\[\[script\]\]/ { in_script=1; file=""; status=""; next }
+      /^\[\[/ && !/^\[\[script\]\]/ { in_script=0; next }
+      !in_script { next }
+      /^file[[:space:]]*=/ { file=$2; next }
+      /^status[[:space:]]*=/ {
+        status=$2;
+        if (file!="") print file "\t" status;
+      }
+    ' "${REPO_ROOT}/scripts/MANIFEST.toml" | sort -u
+  )
+else
+  while IFS= read -r -d '' file; do
+    # Skip _common and _archive directories
+    [[ "$file" == *"/_common/"* || "$file" == *"/_archive/"* ]] && continue
+
+    total=$((total + 1))
+
+    if head -5 "$file" | grep -qE "@file"; then
+      skipped=$((skipped + 1))
+      [[ "$VERBOSE" == "true" ]] && echo "  ⏭️  Already has header: ${file#${REPO_ROOT}/}"
+      continue
+    fi
+
+    add_header "$file"
+    added=$((added + 1))
+  done < <(find "${TARGET_DIR}" -name "*.sh" -type f -print0 | sort -z)
+fi
 
 echo ""
 echo "────────────────────────────────────────────────────"

--- a/scripts/error-triage-engine.sh
+++ b/scripts/error-triage-engine.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # @file        scripts/error-triage-engine.sh
 # @module      operations
-# @description error triage engine — on-prem code-server
+# @description Automated error pattern detection and GitHub issue creation for recurring errors.
 # @owner       platform
 # @status      active
 # ════════════════════════════════════════════════════════════════════════════════════════════

--- a/scripts/vpn-endpoint-testing.sh
+++ b/scripts/vpn-endpoint-testing.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # @file        scripts/vpn-endpoint-testing.sh
 # @module      networking
-# @description vpn endpoint testing — on-prem code-server
+# @description Test VPN endpoint connectivity and service health.
 # @owner       platform
 # @status      active
 # ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
Implements a single-source, fail-closed GOV-002 enforcement path for active scripts.

## Changes
- add canonical checker for active MANIFEST scripts metadata policy
- scope MANIFEST parsing strictly to [[script]] sections
- wire pre-commit metadata hook to canonical checker
- wire CI ile-header-coverage to same checker
- extend migration tool with --active-only
- remediate active-script purpose/header drift cases

## Validation
- ash scripts/ci/check-metadata-headers.sh => Failures: 0

Fixes #297