### PR TITLE
feat(ai): retrieval quality metrics + 20-case indexing benchmark suite (P2 #393)

### DIFF
--- a/backend/src/services/ai/__tests__/indexing-quality.test.ts
+++ b/backend/src/services/ai/__tests__/indexing-quality.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  RepositoryIndexer,
+  evaluateRetrievalQuality,
+  type RetrievalBenchmarkCase,
+  type RepositoryFile,
+} from "../indexing";
+
+const CORPUS: RepositoryFile[] = [
+  { path: "src/auth/login.ts", content: "function loginUser token validate session cookie" },
+  { path: "src/auth/logout.ts", content: "function logoutUser revoke session token" },
+  { path: "src/auth/refresh.ts", content: "function refreshToken rotate jwt expiry" },
+  { path: "src/db/users.ts", content: "function queryUsers postgres index where email" },
+  { path: "src/db/orders.ts", content: "function queryOrders postgres join orderItems" },
+  { path: "src/cache/redis.ts", content: "function cacheSet redis ttl key value" },
+  { path: "src/cache/invalidate.ts", content: "function invalidateCache redis delete key" },
+  { path: "src/http/router.ts", content: "function routeRequest express middleware handler" },
+  { path: "src/http/retry.ts", content: "function retryRequest backoff timeout http client" },
+  { path: "src/observability/tracing.ts", content: "function traceSpan opentelemetry jaeger exporter" },
+  { path: "src/observability/logging.ts", content: "function logEvent json structured correlation" },
+  { path: "src/queue/worker.ts", content: "function processQueue async worker concurrency" },
+  { path: "src/queue/scheduler.ts", content: "function scheduleJob cron interval nextRun" },
+  { path: "src/security/rbac.ts", content: "function enforceRbac role permission policy" },
+  { path: "src/security/audit.ts", content: "function writeAudit immutable event chain" },
+  { path: "src/deploy/compose.ts", content: "function deployCompose docker service healthcheck" },
+  { path: "src/deploy/rollback.ts", content: "function rollbackDeploy version revert release" },
+  { path: "src/ai/indexer.ts", content: "function chunkSemantic overlap token deduplicate" },
+  { path: "src/ai/search.ts", content: "function searchChunks ranking precision recall" },
+  { path: "src/ai/bench.ts", content: "function benchmarkRetrieval p95 latency hitrate" },
+];
+
+const CASES: RetrievalBenchmarkCase[] = [
+  { query: "login token session", expectedFilePaths: ["src/auth/login.ts"] },
+  { query: "logout revoke session", expectedFilePaths: ["src/auth/logout.ts"] },
+  { query: "rotate jwt expiry", expectedFilePaths: ["src/auth/refresh.ts"] },
+  { query: "postgres query users", expectedFilePaths: ["src/db/users.ts"] },
+  { query: "orders join postgres", expectedFilePaths: ["src/db/orders.ts"] },
+  { query: "redis ttl key value", expectedFilePaths: ["src/cache/redis.ts"] },
+  { query: "invalidate redis delete", expectedFilePaths: ["src/cache/invalidate.ts"] },
+  { query: "express middleware handler", expectedFilePaths: ["src/http/router.ts"] },
+  { query: "retry timeout backoff", expectedFilePaths: ["src/http/retry.ts"] },
+  { query: "opentelemetry jaeger span", expectedFilePaths: ["src/observability/tracing.ts"] },
+  { query: "structured json correlation", expectedFilePaths: ["src/observability/logging.ts"] },
+  { query: "queue worker concurrency", expectedFilePaths: ["src/queue/worker.ts"] },
+  { query: "cron schedule interval", expectedFilePaths: ["src/queue/scheduler.ts"] },
+  { query: "rbac role permission", expectedFilePaths: ["src/security/rbac.ts"] },
+  { query: "audit immutable chain", expectedFilePaths: ["src/security/audit.ts"] },
+  { query: "docker compose healthcheck", expectedFilePaths: ["src/deploy/compose.ts"] },
+  { query: "rollback release revert", expectedFilePaths: ["src/deploy/rollback.ts"] },
+  { query: "semantic chunk overlap", expectedFilePaths: ["src/ai/indexer.ts"] },
+  { query: "ranking precision recall", expectedFilePaths: ["src/ai/search.ts"] },
+  { query: "benchmark p95 hitrate", expectedFilePaths: ["src/ai/bench.ts"] },
+];
+
+describe("evaluateRetrievalQuality", () => {
+  it("computes precision/recall/hit-rate over 20 benchmark cases", async () => {
+    const indexer = new RepositoryIndexer({ chunkSizeTokens: 32, chunkOverlapTokens: 4 });
+    await indexer.indexRepository(CORPUS);
+
+    const result = evaluateRetrievalQuality(indexer, CASES, 3);
+
+    expect(result.totalCases).toBe(20);
+    expect(result.hitRate).toBeGreaterThanOrEqual(0.9);
+    expect(result.precision).toBeGreaterThanOrEqual(0.9);
+    expect(result.recall).toBeGreaterThanOrEqual(0.9);
+    expect(result.p95LatencyMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/backend/src/services/ai/index.ts
+++ b/backend/src/services/ai/index.ts
@@ -5,6 +5,7 @@ export {
 	inferLanguage,
 	semanticBoundaries,
 	chunkByTokenWindow,
+	evaluateRetrievalQuality,
 } from "./indexing";
 export type {
 	SupportedLanguage,
@@ -14,4 +15,6 @@ export type {
 	IndexingOptions,
 	IndexingResult,
 	SearchResult,
+	RetrievalBenchmarkCase,
+	RetrievalQualityMetrics,
 } from "./indexing";

--- a/backend/src/services/ai/indexing.ts
+++ b/backend/src/services/ai/indexing.ts
@@ -48,6 +48,20 @@ export interface SearchResult {
   score: number;
 }
 
+export interface RetrievalBenchmarkCase {
+  query: string;
+  expectedFilePaths: string[];
+}
+
+export interface RetrievalQualityMetrics {
+  totalCases: number;
+  hitRate: number;
+  precision: number;
+  recall: number;
+  avgLatencyMs: number;
+  p95LatencyMs: number;
+}
+
 type QueueTask = () => Promise<void>;
 
 const DEFAULT_OPTIONS: IndexingOptions = {
@@ -323,6 +337,69 @@ export function chunkByTokenWindow(content: string, chunkSizeTokens: number, ove
   }
 
   return chunks;
+}
+
+export function evaluateRetrievalQuality(
+  indexer: RepositoryIndexer,
+  cases: RetrievalBenchmarkCase[],
+  limit = 5,
+): RetrievalQualityMetrics {
+  if (cases.length === 0) {
+    return {
+      totalCases: 0,
+      hitRate: 0,
+      precision: 0,
+      recall: 0,
+      avgLatencyMs: 0,
+      p95LatencyMs: 0,
+    };
+  }
+
+  let hits = 0;
+  let totalTp = 0;
+  let totalFp = 0;
+  let totalFn = 0;
+  const latencies: number[] = [];
+
+  for (const testCase of cases) {
+    const started = process.hrtime.bigint();
+    const results = indexer.search(testCase.query, limit);
+    const elapsedNs = process.hrtime.bigint() - started;
+    latencies.push(Number(elapsedNs) / 1_000_000);
+
+    const predicted = new Set(results.map((r) => r.chunk.metadata.filePath));
+    const expected = new Set(testCase.expectedFilePaths);
+
+    let tp = 0;
+    for (const file of predicted) {
+      if (expected.has(file)) tp += 1;
+    }
+
+    const fp = Math.max(0, predicted.size - tp);
+    const fn = Math.max(0, expected.size - tp);
+
+    totalTp += tp;
+    totalFp += fp;
+    totalFn += fn;
+    if (tp > 0) hits += 1;
+  }
+
+  const avgLatencyMs = latencies.reduce((acc, v) => acc + v, 0) / latencies.length;
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const p95Index = Math.max(0, Math.ceil(sorted.length * 0.95) - 1);
+  const p95LatencyMs = sorted[p95Index] ?? 0;
+
+  const precisionDenominator = totalTp + totalFp;
+  const recallDenominator = totalTp + totalFn;
+
+  return {
+    totalCases: cases.length,
+    hitRate: hits / cases.length,
+    precision: precisionDenominator > 0 ? totalTp / precisionDenominator : 0,
+    recall: recallDenominator > 0 ? totalTp / recallDenominator : 0,
+    avgLatencyMs,
+    p95LatencyMs,
+  };
 }
 
 function estimateTokenCount(content: string): number {


### PR DESCRIPTION
## Summary
Advance #393 with measurable retrieval-quality instrumentation and benchmark coverage.

## Changes
- add evaluateRetrievalQuality() in indexing service
- add benchmark types (RetrievalBenchmarkCase, RetrievalQualityMetrics)
- export new API from AI service barrel
- add 20-case quality benchmark test suite for indexing search relevance

## Why
Adds objective quality metrics (hit-rate, precision, recall, avg latency, p95 latency) and a repeatable benchmark corpus for regression detection.

## Validation
- Added test file: backend/src/services/ai/__tests__/indexing-quality.test.ts
- Root test runner unavailable in this workspace (no root package.json), so CI should execute suite in project context.

Refs #393