### PR TITLE
feat(governance): automate governance score tracking and PR reporting (GOV-008 #303)

### DIFF
--- a/.github/workflows/governance-enforcement.yml
+++ b/.github/workflows/governance-enforcement.yml
@@ -57,6 +57,25 @@ jobs:
           else
             echo "⚠ Trivy archive not found for v${TRIVY_VERSION}; continuing (advisory scan step may skip)"
           fi
+
+      - name: Calculate governance score
+        run: |
+          bash scripts/governance/calculate-governance-score.sh --format env >> "$GITHUB_ENV"
+
+      - name: Publish governance score summary
+        run: |
+          {
+            echo "## Governance Score"
+            echo
+            echo "| Signal | Count | Penalty |"
+            echo "|---|---:|---:|"
+            echo "| jscpd violations | ${JSCPD_VIOLATIONS} | $((JSCPD_VIOLATIONS * 5)) |"
+            echo "| missing headers | ${MISSING_HEADERS} | $((MISSING_HEADERS * 2)) |"
+            echo "| hardcoded IP files | ${HARDCODED_IPS} | $((HARDCODED_IPS * 10)) |"
+            echo "| active fallback shims | ${ACTIVE_SHIMS_WITH_FALLBACK} | $((ACTIVE_SHIMS_WITH_FALLBACK * 8)) |"
+            echo
+            echo "**Governance Score:** ${GOVERNANCE_SCORE}/100"
+          } >> "$GITHUB_STEP_SUMMARY"
       
       - name: "[P0] Shellcheck - Shell Scripts"
         continue-on-error: true  # Temporarily disabled to debug other checks
@@ -202,4 +221,70 @@ jobs:
           echo "  ⚠️  Vulnerabilities (Trivy)"
           echo "  ⚠️  IaC security (Checkov)"
           echo ""
+          echo "Governance Score: ${GOVERNANCE_SCORE}/100"
+          echo ""
           echo "════════════════════════════════════════════════════════════════════════════════════════════"
+
+      - name: Post governance score to PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          GOVERNANCE_SCORE: ${{ env.GOVERNANCE_SCORE }}
+          JSCPD_VIOLATIONS: ${{ env.JSCPD_VIOLATIONS }}
+          MISSING_HEADERS: ${{ env.MISSING_HEADERS }}
+          HARDCODED_IPS: ${{ env.HARDCODED_IPS }}
+          ACTIVE_SHIMS_WITH_FALLBACK: ${{ env.ACTIVE_SHIMS_WITH_FALLBACK }}
+        with:
+          script: |
+            const marker = '<!-- governance-score -->';
+            const rows = [
+              ['jscpd violations', process.env.JSCPD_VIOLATIONS, Number(process.env.JSCPD_VIOLATIONS) * 5],
+              ['missing headers', process.env.MISSING_HEADERS, Number(process.env.MISSING_HEADERS) * 2],
+              ['hardcoded IP files', process.env.HARDCODED_IPS, Number(process.env.HARDCODED_IPS) * 10],
+              ['active fallback shims', process.env.ACTIVE_SHIMS_WITH_FALLBACK, Number(process.env.ACTIVE_SHIMS_WITH_FALLBACK) * 8],
+            ];
+            const body = `${marker}
+            ## Governance Score
+
+            | Signal | Count | Penalty |
+            |---|---:|---:|
+            ${rows.map(([name, count, penalty]) => `| ${name} | ${count} | ${penalty} |`).join('\n')}
+
+            **Governance Score:** ${process.env.GOVERNANCE_SCORE}/100
+
+            Formula:
+            
+            \`\`\`
+            score = max(0, 100
+                  - (jscpd_violations * 5)
+                  - (missing_headers * 2)
+                  - (hardcoded_ips * 10)
+                  - (active_shims_with_fallback * 8))
+            \`\`\`
+            `;
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -772,6 +772,12 @@ If Z happens, do W
 - Blocks merges of phase-numbered files
 - Warns about duplicate config files
 
+**Governance Score Tracking**:
+- `.github/workflows/governance-enforcement.yml` calculates a composite governance score on PRs
+- Score inputs come from canonical checks only: jscpd, metadata headers, hardcoded IPs, fallback shims
+- Monthly governance reporting exports the same score to Prometheus artifacts and the governance debt issue thread
+- GitHub Project `Governance Debt Tracker` uses `Governance Score` as the numeric tracking field for governance debt items
+
 ### 2. Manual Governance
 
 **Monthly Structure Review**:

--- a/docs/governance/POLICY.md
+++ b/docs/governance/POLICY.md
@@ -393,6 +393,31 @@ governance_remediation_sla_days      # SLA timer for fixing violations
 **Weekly**: Governance violation summary (team Slack digest)  
 **Monthly**: Full governance debt report (email + dashboard)
 
+### 3.3 Governance Score
+
+GitHub Project `Governance Debt Tracker` and the governance enforcement workflow track a composite governance score from **0–100**.
+
+Formula:
+
+```text
+score = max(0, 100
+  - (jscpd_violations * 5)
+  - (missing_headers * 2)
+  - (hardcoded_ips * 10)
+  - (active_shims_with_fallback * 8))
+```
+
+Inputs are derived from canonical repository checks only:
+- `jscpd_violations`: duplicate clusters detected by `jscpd`
+- `missing_headers`: active `scripts/MANIFEST.toml` entries missing `@file/@module/@description`
+- `hardcoded_ips`: active top-level scripts with raw `192.168.168.x` references
+- `active_shims_with_fallback`: compatibility shims still retaining fallback implementations
+
+Usage:
+- PR workflow posts the current score as a comment and step summary.
+- Monthly governance report exports the score as Prometheus metrics.
+- GitHub Project field `Governance Score` stores the current debt posture for governance issues.
+
 ---
 
 ## 4. Toolchain Configuration

--- a/scripts/governance/calculate-governance-score.sh
+++ b/scripts/governance/calculate-governance-score.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# @file        scripts/governance/calculate-governance-score.sh
+# @module      governance/metrics
+# @description Calculate governance debt counts and composite governance score from canonical repo checks
+#
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="${REPO_ROOT}/scripts/MANIFEST.toml"
+FORMAT="env"
+
+usage() {
+  cat <<'EOF'
+Usage: calculate-governance-score.sh [--format env|markdown|prometheus]
+
+Outputs governance score inputs derived from canonical repo checks:
+- jscpd violations
+- missing metadata headers in active MANIFEST scripts
+- hardcoded IP files in active top-level scripts
+- active compatibility shims with fallback implementations
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --format)
+      FORMAT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "scripts/MANIFEST.toml not found: ${MANIFEST}" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+count_jscpd_violations() {
+  local report_dir="${TMP_DIR}/jscpd"
+  local report_file="${report_dir}/jscpd-report.json"
+
+  mkdir -p "${report_dir}"
+
+  if ! command -v jscpd >/dev/null 2>&1; then
+    echo 0
+    return 0
+  fi
+
+  (
+    cd "${REPO_ROOT}"
+    jscpd \
+      --min-lines 5 \
+      --min-tokens 30 \
+      --threshold 0.9 \
+      --exclude-pattern '**/archived/**' \
+      --exclude-pattern '**/.git/**' \
+      --exclude-pattern '**/node_modules/**' \
+      --reporter json \
+      --output "${report_dir}" \
+      . >/dev/null 2>&1 || true
+  )
+
+  if [[ ! -f "${report_file}" ]]; then
+    echo 0
+    return 0
+  fi
+
+  jq -r '
+    if (.duplicates? | type) == "array" then
+      (.duplicates | length)
+    elif (.clones? | type) == "array" then
+      (.clones | length)
+    elif .statistics.total.duplicates? then
+      .statistics.total.duplicates
+    elif .statistics.total.clones? then
+      .statistics.total.clones
+    else
+      0
+    end
+  ' "${report_file}" 2>/dev/null || echo 0
+}
+
+count_missing_headers() {
+  local failures=0
+  local rel_path
+  local purpose
+  local script_path
+  local header
+
+  while IFS=$'\t' read -r rel_path purpose; do
+    script_path="${REPO_ROOT}/scripts/${rel_path}"
+
+    if [[ ! -f "${script_path}" ]]; then
+      failures=$((failures + 1))
+      continue
+    fi
+
+    header="$(head -12 "${script_path}")"
+    if ! grep -qE '^# @file[[:space:]]+scripts/' <<<"${header}" \
+      || ! grep -qE '^# @module[[:space:]]+[^[:space:]].*$' <<<"${header}" \
+      || ! grep -qE '^# @description[[:space:]]+[^[:space:]].*$' <<<"${header}"; then
+      failures=$((failures + 1))
+    fi
+  done < <(
+    awk -F '"' '
+      BEGIN { in_script=0; file=""; status=""; purpose="" }
+      /^\[\[script\]\]/ { in_script=1; file=""; status=""; purpose=""; next }
+      /^\[\[/ && !/^\[\[script\]\]/ { in_script=0; next }
+      !in_script { next }
+      /^file[[:space:]]*=/ { file=$2; next }
+      /^status[[:space:]]*=/ { status=$2; next }
+      /^purpose[[:space:]]*=/ {
+        purpose=$2;
+        if (status=="active" && file!="") {
+          print file "\t" purpose;
+        }
+        next
+      }
+    ' "${MANIFEST}" | sort -u
+  )
+
+  echo "${failures}"
+}
+
+count_hardcoded_ip_files() {
+  local count=0
+
+  count=$(find "${REPO_ROOT}/scripts" -maxdepth 1 -type f -name '*.sh' -print0 \
+    | xargs -0 grep -lE '192\.168\.168\.(30|31|42)\b' 2>/dev/null || true)
+  count=$(printf '%s\n' "${count}" | sed '/^$/d' | wc -l | tr -d ' ')
+
+  echo "${count:-0}"
+}
+
+count_active_shims_with_fallback() {
+  local count=0
+  local file
+
+  while IFS= read -r -d '' file; do
+    if grep -q 'compatibility shim' "${file}" && grep -q 'Fallback: original implementation' "${file}"; then
+      count=$((count + 1))
+    fi
+  done < <(find "${REPO_ROOT}/scripts" -maxdepth 1 -type f -name '*.sh' -print0)
+
+  echo "${count}"
+}
+
+JSCPD_VIOLATIONS="$(count_jscpd_violations)"
+MISSING_HEADERS="$(count_missing_headers)"
+HARDCODED_IPS="$(count_hardcoded_ip_files)"
+ACTIVE_SHIMS_WITH_FALLBACK="$(count_active_shims_with_fallback)"
+
+RAW_SCORE=$((100 \
+  - (JSCPD_VIOLATIONS * 5) \
+  - (MISSING_HEADERS * 2) \
+  - (HARDCODED_IPS * 10) \
+  - (ACTIVE_SHIMS_WITH_FALLBACK * 8)))
+
+if (( RAW_SCORE < 0 )); then
+  GOVERNANCE_SCORE=0
+elif (( RAW_SCORE > 100 )); then
+  GOVERNANCE_SCORE=100
+else
+  GOVERNANCE_SCORE="${RAW_SCORE}"
+fi
+
+case "${FORMAT}" in
+  env)
+    cat <<EOF
+GOVERNANCE_SCORE=${GOVERNANCE_SCORE}
+JSCPD_VIOLATIONS=${JSCPD_VIOLATIONS}
+MISSING_HEADERS=${MISSING_HEADERS}
+HARDCODED_IPS=${HARDCODED_IPS}
+ACTIVE_SHIMS_WITH_FALLBACK=${ACTIVE_SHIMS_WITH_FALLBACK}
+EOF
+    ;;
+  markdown)
+    cat <<EOF
+## Governance Score
+
+| Signal | Count | Penalty |
+|---|---:|---:|
+| jscpd violations | ${JSCPD_VIOLATIONS} | $((JSCPD_VIOLATIONS * 5)) |
+| missing headers | ${MISSING_HEADERS} | $((MISSING_HEADERS * 2)) |
+| hardcoded IP files | ${HARDCODED_IPS} | $((HARDCODED_IPS * 10)) |
+| active fallback shims | ${ACTIVE_SHIMS_WITH_FALLBACK} | $((ACTIVE_SHIMS_WITH_FALLBACK * 8)) |
+
+**Governance Score:** ${GOVERNANCE_SCORE}/100
+
+Formula:
+
+\`\`\`
+score = max(0, 100
+      - (jscpd_violations * 5)
+      - (missing_headers * 2)
+      - (hardcoded_ips * 10)
+      - (active_shims_with_fallback * 8))
+\`\`\`
+EOF
+    ;;
+  prometheus)
+    cat <<EOF
+# HELP governance_score Composite governance score for the current repository snapshot.
+# TYPE governance_score gauge
+governance_score ${GOVERNANCE_SCORE}
+# HELP governance_score_jscpd_violations jscpd duplicate clusters contributing to governance score penalty.
+# TYPE governance_score_jscpd_violations gauge
+governance_score_jscpd_violations ${JSCPD_VIOLATIONS}
+# HELP governance_score_missing_headers Active MANIFEST scripts missing required metadata headers.
+# TYPE governance_score_missing_headers gauge
+governance_score_missing_headers ${MISSING_HEADERS}
+# HELP governance_score_hardcoded_ips Active top-level scripts containing hardcoded IP addresses.
+# TYPE governance_score_hardcoded_ips gauge
+governance_score_hardcoded_ips ${HARDCODED_IPS}
+# HELP governance_score_active_shims_with_fallback Active compatibility shims retaining fallback implementations.
+# TYPE governance_score_active_shims_with_fallback gauge
+governance_score_active_shims_with_fallback ${ACTIVE_SHIMS_WITH_FALLBACK}
+EOF
+    ;;
+  *)
+    echo "Unsupported format: ${FORMAT}" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/governance/generate-monthly-report.sh
+++ b/scripts/governance/generate-monthly-report.sh
@@ -22,6 +22,21 @@ MONTH_LABEL="$(date -u +%Y-%m)"
 OUT_DIR=".github/reports/governance"
 METRICS_FILE="$OUT_DIR/governance_metrics_${MONTH_LABEL}.prom"
 REPORT_FILE="$OUT_DIR/governance_report_${MONTH_LABEL}.md"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if ! SCORE_OUTPUT="$(${REPO_ROOT}/scripts/governance/calculate-governance-score.sh --format env)"; then
+  echo "Failed to calculate governance score" >&2
+  exit 1
+fi
+
+while IFS='=' read -r key value; do
+  case "$key" in
+    GOVERNANCE_SCORE|JSCPD_VIOLATIONS|MISSING_HEADERS|HARDCODED_IPS|ACTIVE_SHIMS_WITH_FALLBACK)
+      printf -v "$key" '%s' "$value"
+      ;;
+  esac
+done <<< "$SCORE_OUTPUT"
 
 mkdir -p "$OUT_DIR"
 
@@ -61,6 +76,21 @@ governance_orphaned_issues ${ORPHANED_OPEN}
 # HELP governance_consolidation_ratio Consolidation ratio based on canonical-closed issues over tracked duplicate/canonical universe.
 # TYPE governance_consolidation_ratio gauge
 governance_consolidation_ratio ${CONSOLIDATION_RATIO}
+# HELP governance_score Composite governance score for current repo snapshot.
+# TYPE governance_score gauge
+governance_score ${GOVERNANCE_SCORE}
+# HELP governance_score_jscpd_violations jscpd duplicate clusters contributing to score penalty.
+# TYPE governance_score_jscpd_violations gauge
+governance_score_jscpd_violations ${JSCPD_VIOLATIONS}
+# HELP governance_score_missing_headers Active MANIFEST scripts missing required metadata headers.
+# TYPE governance_score_missing_headers gauge
+governance_score_missing_headers ${MISSING_HEADERS}
+# HELP governance_score_hardcoded_ips Active top-level scripts containing hardcoded IP addresses.
+# TYPE governance_score_hardcoded_ips gauge
+governance_score_hardcoded_ips ${HARDCODED_IPS}
+# HELP governance_score_active_shims_with_fallback Active compatibility shims retaining fallback implementations.
+# TYPE governance_score_active_shims_with_fallback gauge
+governance_score_active_shims_with_fallback ${ACTIVE_SHIMS_WITH_FALLBACK}
 # HELP governance_report_timestamp_seconds Unix timestamp of governance report generation.
 # TYPE governance_report_timestamp_seconds gauge
 governance_report_timestamp_seconds $(date -u +%s)
@@ -79,6 +109,16 @@ Repository: ${REPO}
 | governance_duplicate_issues | ${DUPLICATE_OPEN} |
 | governance_orphaned_issues | ${ORPHANED_OPEN} |
 | governance_consolidation_ratio | ${CONSOLIDATION_RATIO} |
+| governance_score | ${GOVERNANCE_SCORE} |
+
+## Governance Score Breakdown
+
+| Signal | Count | Penalty |
+|---|---:|---:|
+| jscpd violations | ${JSCPD_VIOLATIONS} | $((JSCPD_VIOLATIONS * 5)) |
+| missing headers | ${MISSING_HEADERS} | $((MISSING_HEADERS * 2)) |
+| hardcoded IP files | ${HARDCODED_IPS} | $((HARDCODED_IPS * 10)) |
+| active fallback shims | ${ACTIVE_SHIMS_WITH_FALLBACK} | $((ACTIVE_SHIMS_WITH_FALLBACK * 8)) |
 
 ## Inputs
 
@@ -88,6 +128,16 @@ Repository: ${REPO}
 | duplicate_closed | ${DUPLICATE_CLOSED} |
 | canonical_open | ${CANONICAL_OPEN} |
 | canonical_closed | ${CANONICAL_CLOSED} |
+
+Formula:
+
+```
+score = max(0, 100
+  - (jscpd_violations * 5)
+  - (missing_headers * 2)
+  - (hardcoded_ips * 10)
+  - (active_shims_with_fallback * 8))
+```
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add canonical governance score calculator script with env/markdown/prometheus outputs
- wire governance score into governance enforcement workflow and post/update PR comment
- extend monthly governance report to emit governance score metrics and breakdown
- document governance score formula and tracking command updates in governance docs

## Validation
- bash scripts/governance/calculate-governance-score.sh --format env
- label check: governance-debt exists with expected color/description
- project check: Governance Debt Tracker includes Governance Score custom field

## Notes
- monthly report script requires gh CLI in runtime environment (works in CI/Linux host)

Fixes #303