### PR TITLE
docs(roadmap): add master execution plan for elite program (#383)

### DIFF
--- a/docs/MASTER-EXECUTION-PLAN.md
+++ b/docs/MASTER-EXECUTION-PLAN.md
@@ -1,0 +1,239 @@
+# Master Execution Plan
+
+Document version: 1.0  
+Created: April 15, 2026  
+Status: Approved for execution  
+Target completion: 10-12 weeks  
+Document owner: Architecture + SRE  
+Next review: April 22, 2026
+
+## Purpose
+
+This roadmap defines the execution sequence for the Elite Enterprise Environment Program, with explicit critical-path ordering, parallel tracks, dependencies, approval gates, and measurable outcomes.
+
+## I. Critical Path
+
+### Phase 1: Security Hardening (Week 1)
+
+Goal: Stop active security bleeding before building new capabilities.
+
+| Issue | Title | Effort | Owner | Exit Criteria |
+|---|---|---|---|---|
+| #370 | Rotate all default credentials (P0) | 2 days | Ops/Security | All secrets rotated; Vault AppRole deployed; `.env-prod` validated |
+| #371 | Restore CI validation gate (P1) | 3 days | DevOps | gitleaks, checkov, tfsec all running; 0 secrets leaked |
+| #372 | Network isolation for PostgreSQL/Redis (P1) | 5 days | Infra | Docker networks segmented; DB ports not exposed to `0.0.0.0` |
+
+Gate: all three issues merged before proceeding to Phase 2.
+
+### Phase 2: Governance Foundation (Week 2)
+
+Goal: Establish the policy engine that prevents future drift.
+
+| Issue | Title | Effort | Owner | Exit Criteria |
+|---|---|---|---|---|
+| #380 | Unified code governance framework | 3 weeks | Architecture/DevOps | jscpd, knip, shellcheck, SAST orchestrated; CI enforcing |
+| #379 | Consolidate duplicate issue tracks | 1 week | Scrum Master | Parallel GOV and QA issue tracks merged into canonical single issues |
+| #376 | Define information architecture (ADR only) | 1 week | Architecture | Five-level folder placement rules approved |
+
+Gate: #380 CI enforcement live before code restructuring.
+
+### Phase 3: Observability Spine (Weeks 3-6)
+
+Goal: Enable incident response in under 15 minutes.
+
+| Issue | Title | Effort | Owner | Exit Criteria |
+|---|---|---|---|---|
+| #377 | End-to-end telemetry (Cloudflare to containers) | 4-6 weeks | Observability | All requests have trace ID; Jaeger receives 100% traces; latency decomposition visible in dashboards |
+| #381 | Production readiness gates (design phase only) | 1 week | QA/Architecture | Design certification form approved |
+
+Gate: #377 deployed and tested under load before the #381 operations gate.
+
+### Phase 4: Quality Gates (Week 5)
+
+Goal: Lock down production quality standards.
+
+| Issue | Title | Effort | Owner | Exit Criteria |
+|---|---|---|---|---|
+| #381 | Production readiness certification (4-phase gate) | 2-3 weeks | QA | Design, implementation, operations, and SLA gates operational; peer review assignment automated |
+| #374 | Alert coverage gaps (backup, cert, replication, disk, etc.) | 1 week | Observability | Six new alerts deployed; all have runbook links |
+
+Gate: #381 gates required for all PRs merging after the grace period.
+
+### Phase 5: Operability and Clarity (Weeks 7-9)
+
+Goal: Make operational tasks self-documenting and unambiguous.
+
+| Issue | Title | Effort | Owner | Exit Criteria |
+|---|---|---|---|---|
+| #376 | Reorganize root files and scripts | 3 weeks | Architecture/DevOps | Root has fewer than 10 files; `scripts/` root has fewer than 20 files; links verified; CI enforcing |
+| #382 | Canonical script organization (entrypoints) | 2 weeks | DevOps | Fewer than 20 canonical scripts for deploy/health/recovery; phase variants deprecated |
+| #378 | Error fingerprinting to GitHub triage | 3-4 weeks | SRE/Automation | Runtime errors auto-open issues; duplicate clustering works |
+
+Gate: #376 structure enforcement lands before #382 script organization.
+
+### Phase 6: Finishing (Weeks 10-12)
+
+Goal: Finish consolidation and measure outcomes.
+
+| Issue | Title | Effort | Owner | Exit Criteria |
+|---|---|---|---|---|
+| #373 | Caddyfile consolidation (4 variants to 1 template) | 1 week | Infra | Only `Caddyfile.tpl` remains in git; render targets work for production and on-prem |
+| Supportive | Measure MTTR, duplicate rate, CI violations, structure compliance | 2 weeks | Scrum Master | Baseline metrics established; SLA trend positive |
+
+## II. Parallel Tracks
+
+### Infrastructure Modernization (Week 1-12)
+
+| Issue | Title | Effort | Dependencies | Status |
+|---|---|---|---|---|
+| #362 | Environment abstraction epic (VIP, VRRP, DNS, inventory) | 6-8 weeks | None | In progress |
+| #363 | CoreDNS deployment | 2 weeks | #362 | Pending |
+| #365 | VRRP/Keepalived VIP floating | 2 weeks | #362, #363 | Pending |
+| #366 | Replace hardcoded IPs with inventory and FQDNs | 2 weeks | #364 inventory | Unblock when inventory work completes |
+
+## III. Full Backlog Sequencing
+
+```text
+CRITICAL PATH
+Week 1       #370 -> #371 -> #372
+Week 2       #380 + #379 + #376 ADR
+Weeks 3-6    #377 + #381 design approval
+Week 5       #381 full gate + #374 alerts
+Weeks 7-9    #376 structure -> #382 scripts -> #378 triage
+Weeks 10-12  #373 consolidation + measurement
+
+PARALLEL
+Throughout: #362 with #363, #365, #366, #367
+
+SUPPORTIVE
+#327, #355, #358, #359
+```
+
+## IV. Resource Allocation
+
+| Role | Capacity | Key Issues | Notes |
+|---|---|---|---|
+| DevOps/SRE | 80% | #370, #371, #372, #380, #377, #382, #376 | Critical-path blocker |
+| QA/Architecture | 60% | #381, #379, #376 ADR, #374 | Design and governance focus |
+| Backend/Platform | 40% | #362, #363, #365 | Parallel infrastructure |
+| Observability Engineering | 100% | #377, #378, #374 | Specialized domain |
+
+Team size assumption: four engineers, three months, full critical-path allocation.
+
+## V. Success Metrics and SLA Targets
+
+### Operational Metrics
+
+| Metric | Baseline | Target (Week 12) | Measurement Method |
+|---|---|---|---|
+| MTTR (incident to trace) | 2+ hours | under 15 minutes | Trace-based RCA walkthrough |
+| Duplicate issues per month | about 10 | under 1 | GitHub issue analytics |
+| Production code quality violations per PR | about 30% | 0% after grace period | #380 CI enforcement report |
+| Unplanned outages from governance gaps | about 1 per month | 0 | Incident review correlation |
+
+### Structural Metrics
+
+| Metric | Baseline | Target | Timeline |
+|---|---|---|---|
+| Root markdown files | 280 | under 10 | Week 7 (#376) |
+| Scripts at root | 157 | under 20 | Week 8 (#382) |
+| Alert rule file variants | 4 | 1 | Week 2 (#374) |
+| Config variants (compose, Caddyfile, etc.) | 12 | 3 | Week 10 (#373) |
+
+### Governance Metrics
+
+| Metric | Baseline | Target | Timeline |
+|---|---|---|---|
+| CI governance violations per PR | 30% | 0% | Week 2 (#380) |
+| Duplicate code (jscpd threshold) | High | under 5% | Week 2 (#380) |
+| Unused code (knip) | Unknown | under 2% of codebase | Week 2 (#380) |
+| Policy waiver rate | N/A | under 2% | Week 3 (#380) |
+
+## VI. Critical Dependencies and Blockers
+
+### Hard Blockers
+
+- #370 must complete before #371 CI validation can pass cleanly.
+- #380 must be operational before Phase 5 structure work starts.
+- #377 must be live before #378 error triage can attach telemetry evidence.
+
+### Soft Dependencies
+
+- #362 can proceed in parallel, but #366 should wait until #376 structure policy is enforced in CI.
+- #381 design can be approved before #377 is live, but implementation still needs the #377 observability plan finalized.
+
+## VII. Risk Mitigation
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| #380 governance too strict | Medium | High | Ship waiver workflow early; use a grace period before hard enforcement |
+| #377 telemetry breaks production | Low | Critical | Stage first; use limited sampling; auto-rollback on error spike |
+| #376 structure migration causes link rot | High | Medium | Enforce link checking in CI; document migration map |
+| Team context loss during refactoring | Medium | Medium | Record each phase in issues; preserve history; use pairing for transfer |
+| Merge conflicts from parallel work | Medium | Low | Daily integration checks; frequent rebases; active coordination |
+
+## VIII. Hand-Off and Approval Gates
+
+### Week 1-2 Approval Gates
+
+- Security gate: #370 complete, zero secrets in git, CI passing.
+- Governance gate: #380 approved by architecture and security review.
+- Dedupe gate: #379 reviewed; canonical issues identified.
+
+### Week 3 Approval Gate
+
+- Observability gate: #377 architecture approved; Jaeger pilot successful.
+
+### Week 7 Approval Gate
+
+- Structure gate: #376 policy enforced; CI blocks root-file sprawl.
+
+### Week 12 Exit Gate
+
+- SLA validation trends toward targets.
+- No new production regressions from reorganization work.
+- Engineers trained on the new structure, governance, and gates.
+
+## IX. Communication and Tracking
+
+### Daily Standup
+
+- Review critical-path blockers.
+- Coordinate dependencies, especially #362 vs #376 and #382.
+- Review CI and branch status.
+
+### Weekly Governance Review
+
+- Progress on #375 epic child issues.
+- #379 duplicate consolidation status.
+- #380 governance metrics: violations, waivers, and trends.
+
+### Biweekly Architecture Review
+
+- #376 structure policy adherence.
+- #377 observability rollout status.
+- #381 readiness gate effectiveness.
+
+### Monthly SLA Review
+
+- MTTR improvement trend.
+- Duplicate issue reduction.
+- Governance overhead versus benefit.
+
+## X. Glossary
+
+| Acronym | Meaning | Related Issue |
+|---|---|---|
+| MTTR | Mean Time To Recovery | #377, #378 |
+| SLA | Service Level Agreement | #381 |
+| SSOT | Single Source Of Truth | #376, #380 |
+| VRRP | Virtual Router Redundancy Protocol | #365 |
+| eBPF | Extended Berkeley Packet Filter | #359 |
+| APL | Alert Policy Language | #374 |
+
+## Related References
+
+- [GOVERNANCE.md](GOVERNANCE.md)
+- [README.md](README.md)
+- [FILE-ORGANIZATION-GUIDE.md](FILE-ORGANIZATION-GUIDE.md)
+- [runbooks/production-readiness-gate.md](runbooks/production-readiness-gate.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ docs/
 
 - **New to the project?** Start with [../README.md](../README.md) for overview
 - **Want to contribute?** See [../CONTRIBUTING.md](../CONTRIBUTING.md)
+- **Need the execution sequence?** See [MASTER-EXECUTION-PLAN.md](MASTER-EXECUTION-PLAN.md)
 - **Deploying infrastructure?** See [guides/DEPLOYMENT.md](guides/DEPLOYMENT.md)
 - **Troubleshooting issues?** See [guides/TROUBLESHOOTING.md](guides/TROUBLESHOOTING.md)
 - **Understanding architecture?** See [adc/](adc/)


### PR DESCRIPTION
## Summary
Commits the Week 1-12 master execution roadmap from issue #383 into the repository as durable documentation.

## Changes
- add docs/MASTER-EXECUTION-PLAN.md
- link the roadmap from docs/README.md
- preserve the critical path, parallel tracks, gates, dependencies, metrics, and review cadence in repo docs

## Why
Issue #383 existed as planning text only. This PR makes the roadmap auditable, linkable, and versioned in the repository.

Fixes #383