### PR TITLE
fix(sec): bump PyJWT 2.8.1->2.12.0 — remediate high CVE (Dependabot #49)

### DIFF
--- a/services/token-microservice/requirements.txt
+++ b/services/token-microservice/requirements.txt
@@ -7,7 +7,7 @@ Flask-CORS==6.0.0
 Werkzeug==3.1.6
 
 # JWT and cryptography
-PyJWT==2.8.1
+PyJWT==2.12.0
 cryptography==46.0.7
 
 # HTTP client


### PR DESCRIPTION
## Summary
Remediate high-severity Dependabot alert #49: PyJWT accepts unknown \crit\ header extensions.

## Vulnerability
- **Package**: PyJWT
- **Severity**: HIGH
- **Affected**: <= 2.11.0
- **Patched**: 2.12.0
- **Summary**: PyJWT accepted unknown \crit\ JWT header extensions, which could allow attackers to bypass critical JWT header validation checks.

## Change
\services/token-microservice/requirements.txt\: \PyJWT==2.8.1\ → \PyJWT==2.12.0\

## Notes
- No code changes required; 2.12.0 is a backward-compatible patch
- Closes Dependabot alert #49