### PR TITLE
fix(ops): complete DR/chaos rerun hardening for on-prem execution (#314 #315)

### DIFF
--- a/scripts/phase-7c-disaster-recovery-test.sh
+++ b/scripts/phase-7c-disaster-recovery-test.sh
@@ -56,6 +56,11 @@ elapsed_since() {
   echo $(( $(date +%s) - $1 ))
 }
 
+service_running() {
+  local svc="$1"
+  docker inspect --format '{{.State.Status}}' "$svc" 2>/dev/null | grep -q "running"
+}
+
 pg_env() {
   local key="$1"
   docker inspect postgres --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null | awk -F= -v key="$key" '$1 == key { print substr($0, index($0, "=") + 1); exit }'
@@ -257,7 +262,12 @@ section "Phase 7c-4: Full Stack Recovery"
 # T12: All services recover after simultaneous restart
 log_info "T12: Full stack restart recovery..."
 T_START=$(date +%s)
-docker compose restart >/dev/null 2>&1 || docker-compose restart >/dev/null 2>&1
+SERVICES_ORDER=(redis postgres alertmanager jaeger prometheus grafana oauth2-proxy code-server caddy)
+for svc in "${SERVICES_ORDER[@]}"; do
+  if service_running "$svc"; then
+    docker restart "$svc" >/dev/null 2>&1 || true
+  fi
+done
 HEALTHY=0
 for i in $(seq 1 60); do
   sleep 2

--- a/scripts/phase-7e-chaos-testing.sh
+++ b/scripts/phase-7e-chaos-testing.sh
@@ -392,9 +392,19 @@ if [[ "$DRY_RUN" == "true" ]]; then
 else
   TMPFILE="/tmp/chaos-diskfill-$$.dat"
   TMP_FREE_KB=$(df /tmp --output=avail | tail -1 | tr -d ' ')
-  FILL_KB=$(( TMP_FREE_KB * 90 / 100 ))
+  TARGET_KB=$(( TMP_FREE_KB * 90 / 100 ))
+  MAX_FILL_KB=$(( 512 * 1024 ))
+  if [[ "$TARGET_KB" -gt "$MAX_FILL_KB" ]]; then
+    FILL_KB="$MAX_FILL_KB"
+  else
+    FILL_KB="$TARGET_KB"
+  fi
   if [[ "$FILL_KB" -gt 0 ]]; then
-    dd if=/dev/zero of="$TMPFILE" bs=1024 count="$FILL_KB" 2>/dev/null || true
+    if command -v fallocate >/dev/null 2>&1; then
+      fallocate -l "$((FILL_KB * 1024))" "$TMPFILE" 2>/dev/null || dd if=/dev/zero of="$TMPFILE" bs=1024 count="$FILL_KB" status=none 2>/dev/null || true
+    else
+      dd if=/dev/zero of="$TMPFILE" bs=1024 count="$FILL_KB" status=none 2>/dev/null || true
+    fi
   fi
   # Verify key services still healthy
   SERVICES_OK=true


### PR DESCRIPTION
## Summary
Final hardening slice for the on-prem Phase 7c / 7e reruns after live execution exposed two remaining runtime issues.

## Changes
- DR suite: replace full-stack restart dependency on docker compose with direct container restarts
- Chaos suite: cap disk-pressure fill to 512MB and prefer allocate for bounded execution time

## Why
The primary host lacks the docker compose plugin, and the original disk-pressure scenario could take too long on large /tmp volumes. These fixes make both suites complete reliably on the actual host.

Advances #314, #315