### PR TITLE
fix(ops): use log_warn in DR standalone-mode handling (#293)

### DIFF
--- a/scripts/phase-7c-disaster-recovery-test.sh
+++ b/scripts/phase-7c-disaster-recovery-test.sh
@@ -138,11 +138,11 @@ elif pg_exec -c "SELECT pg_is_in_recovery();" -t 2>/dev/null | grep -q "f"; then
     pass "T3: PostgreSQL WAL senders active ($WAL_SENDERS replicas streaming)"
   else
     # WAL_SENDERS=0 is expected in single-node Phase 7c; multi-region replication tracked in #293
-    warn "T3: No active WAL senders — single-node mode (expected until #293 multi-region ships)"
+    log_warn "T3: No active WAL senders — single-node mode (expected until #293 multi-region ships)"
     pass "T3: PostgreSQL standalone — WAL replication deferred to Phase 7 multi-region (#293)"
   fi
 else
-  warn "T3: Cannot determine PostgreSQL replication state (lag=$PG_LAG) — treating as standalone"
+  log_warn "T3: Cannot determine PostgreSQL replication state (lag=$PG_LAG) — treating as standalone"
   pass "T3: PostgreSQL replication state indeterminate — standalone mode assumed"
 fi
 


### PR DESCRIPTION
## Summary
Fixes a verified shell defect in scripts/phase-7c-disaster-recovery-test.sh.

## Problem
The DR script called warn in T3 even though only log_warn is defined/sourced. In standalone-mode detection this could terminate the suite under set -e before finishing the rest of Phase 7c.

## Change
- replace both warn calls with log_warn

## Validation
- reran Phase 7c on 192.168.168.31 after this fix
- result: PASS T1-T15 (15/15)
- PostgreSQL RTO: 1s
- Redis RTO: 2s
- Full-stack recovery: 5s

Advances #293