### PR TITLE
fix(ops): harden VSCode process monitor counting under strict mode (#291)

### DIFF
--- a/scripts/phase-7c-disaster-recovery-test.sh
+++ b/scripts/phase-7c-disaster-recovery-test.sh
@@ -138,11 +138,11 @@ elif pg_exec -c "SELECT pg_is_in_recovery();" -t 2>/dev/null | grep -q "f"; then
     pass "T3: PostgreSQL WAL senders active ($WAL_SENDERS replicas streaming)"
   else
     # WAL_SENDERS=0 is expected in single-node Phase 7c; multi-region replication tracked in #293
-    warn "T3: No active WAL senders — single-node mode (expected until #293 multi-region ships)"
+    log_warn "T3: No active WAL senders — single-node mode (expected until #293 multi-region ships)"
     pass "T3: PostgreSQL standalone — WAL replication deferred to Phase 7 multi-region (#293)"
   fi
 else
-  warn "T3: Cannot determine PostgreSQL replication state (lag=$PG_LAG) — treating as standalone"
+  log_warn "T3: Cannot determine PostgreSQL replication state (lag=$PG_LAG) — treating as standalone"
   pass "T3: PostgreSQL replication state indeterminate — standalone mode assumed"
 fi
 

--- a/scripts/vscode-handle-monitor.sh
+++ b/scripts/vscode-handle-monitor.sh
@@ -27,7 +27,29 @@ echo -e "${BOLD}[1] Terminal & Shell Process Counts${NC}"
 echo "─────────────────────────────────────────────────────"
 
 count_proc() {
-  pgrep -c "$1" 2>/dev/null || echo 0
+  local pattern="$1"
+  local count
+
+  # Keep output strictly numeric even when pgrep exits 1 (no matches).
+  count=$(pgrep -c "$pattern" 2>/dev/null || true)
+  if [[ "$count" =~ ^[0-9]+$ ]]; then
+    echo "$count"
+  else
+    echo 0
+  fi
+}
+
+count_proc_full() {
+  local pattern="$1"
+  local count
+
+  # With pipefail enabled, avoid "wc + fallback" double-output behavior.
+  count=$(pgrep -f "$pattern" 2>/dev/null | wc -l | tr -d '[:space:]' || true)
+  if [[ "$count" =~ ^[0-9]+$ ]]; then
+    echo "$count"
+  else
+    echo 0
+  fi
 }
 
 bash_count=$(count_proc bash)
@@ -56,8 +78,8 @@ echo ""
 echo -e "${BOLD}[2] VSCode Extension Host Processes${NC}"
 echo "─────────────────────────────────────────────────────"
 
-ext_count=$(pgrep -f "extensionHost" 2>/dev/null | wc -l || echo 0)
-renderer_count=$(pgrep -f "renderer" 2>/dev/null | wc -l || echo 0)
+ext_count=$(count_proc_full "extensionHost")
+renderer_count=$(count_proc_full "renderer")
 
 echo -e "  Extension hosts: ${ext_count}"
 echo -e "  Renderer procs:  ${renderer_count}"


### PR DESCRIPTION
## Summary
Fixes strict-shell numeric parsing failures in the VSCode health monitor script.

## Root Cause
With set -euo pipefail, previous pgrep|wc -l || echo 0 and pgrep -c || echo 0 patterns could emit multiple lines (e.g. 