### PR TITLE
fix(copilot): extensionAllowedProposedApi in product.json enables model selection

### DIFF
--- a/config/product-patch.json
+++ b/config/product-patch.json
@@ -1,0 +1,181 @@
+{
+  "nameShort": "code-server",
+  "nameLong": "code-server",
+  "applicationName": "code-server",
+  "dataFolderName": ".code-server",
+  "win32MutexName": "codeserver",
+  "licenseName": "MIT",
+  "licenseUrl": "https://github.com/coder/code-server/blob/main/LICENSE",
+  "serverLicenseUrl": "https://github.com/microsoft/vscode/blob/main/LICENSE.txt",
+  "serverGreeting": [],
+  "serverLicense": [],
+  "serverLicensePrompt": "",
+  "serverApplicationName": "code-server-oss",
+  "serverDataFolderName": ".vscode-server-oss",
+  "tunnelApplicationName": "code-tunnel-oss",
+  "win32DirName": "code-server",
+  "win32NameVersion": "code-server",
+  "win32RegValueName": "CodeOSS",
+  "win32x64AppId": "{{D77B7E06-80BA-4137-BCF4-654B95CCEBC5}",
+  "win32arm64AppId": "{{D1ACE434-89C5-48D1-88D3-E2991DF85475}",
+  "win32x64UserAppId": "{{CC6B787D-37A0-49E8-AE24-8559A032BE0C}",
+  "win32arm64UserAppId": "{{3AEBF0C8-F733-4AD4-BADE-FDB816D53D7B}",
+  "win32AppUserModelId": "coder.code-server",
+  "win32ShellNameShort": "c&ode-server",
+  "win32TunnelServiceMutex": "vscodeoss-tunnelservice",
+  "win32TunnelMutex": "vscodeoss-tunnel",
+  "darwinBundleIdentifier": "com.coder.code.server",
+  "darwinProfileUUID": "47827DD9-4734-49A0-AF80-7E19B11495CC",
+  "darwinProfilePayloadUUID": "CF808BE7-53F3-46C6-A7E2-7EDB98A5E959",
+  "linuxIconName": "com.coder.code.server",
+  "licenseFileName": "LICENSE.txt",
+  "reportIssueUrl": "https://github.com/coder/code-server/issues/new",
+  "nodejsRepository": "https://nodejs.org",
+  "urlProtocol": "code-oss",
+  "webviewContentExternalBaseUrlTemplate": "https://{{uuid}}.vscode-cdn.net/insider/ef65ac1ba57f57f2a3961bfe94aa20481caca4c6/out/vs/workbench/contrib/webview/browser/pre/",
+  "builtInExtensions": [
+    {
+      "name": "ms-vscode.js-debug-companion",
+      "version": "1.1.3",
+      "sha256": "7380a890787452f14b2db7835dfa94de538caf358ebc263f9d46dd68ac52de93",
+      "repo": "https://github.com/microsoft/vscode-js-debug-companion",
+      "metadata": {
+        "id": "99cb0b7f-7354-4278-b8da-6cc79972169d",
+        "publisherId": {
+          "publisherId": "5f5636e7-69ed-4afe-b5d6-8d231fb3d3ee",
+          "publisherName": "ms-vscode",
+          "displayName": "Microsoft",
+          "flags": "verified"
+        },
+        "publisherDisplayName": "Microsoft"
+      }
+    },
+    {
+      "name": "ms-vscode.js-debug",
+      "version": "1.112.0",
+      "sha256": "c24322931434940938f8cf76ebc3dac1e95a5539b9625b165b6672d7f7eafea8",
+      "repo": "https://github.com/microsoft/vscode-js-debug",
+      "metadata": {
+        "id": "25629058-ddac-4e17-abba-74678e126c5d",
+        "publisherId": {
+          "publisherId": "5f5636e7-69ed-4afe-b5d6-8d231fb3d3ee",
+          "publisherName": "ms-vscode",
+          "displayName": "Microsoft",
+          "flags": "verified"
+        },
+        "publisherDisplayName": "Microsoft"
+      }
+    },
+    {
+      "name": "ms-vscode.vscode-js-profile-table",
+      "version": "1.0.10",
+      "sha256": "7361748ddf9fd09d8a2ed1f2a2d7376a2cf9aae708692820b799708385c38e08",
+      "repo": "https://github.com/microsoft/vscode-js-profile-visualizer",
+      "metadata": {
+        "id": "7e52b41b-71ad-457b-ab7e-0620f1fc4feb",
+        "publisherId": {
+          "publisherId": "5f5636e7-69ed-4afe-b5d6-8d231fb3d3ee",
+          "publisherName": "ms-vscode",
+          "displayName": "Microsoft",
+          "flags": "verified"
+        },
+        "publisherDisplayName": "Microsoft"
+      }
+    }
+  ],
+  "defaultChatAgent": {
+    "extensionId": "GitHub.copilot",
+    "chatExtensionId": "GitHub.copilot-chat",
+    "chatExtensionOutputId": "GitHub.copilot-chat.GitHub Copilot Chat.log",
+    "chatExtensionOutputExtensionStateCommand": "github.copilot.debug.extensionState",
+    "documentationUrl": "https://aka.ms/github-copilot-overview",
+    "termsStatementUrl": "https://aka.ms/github-copilot-terms-statement",
+    "privacyStatementUrl": "https://aka.ms/github-copilot-privacy-statement",
+    "skusDocumentationUrl": "https://aka.ms/github-copilot-plans",
+    "publicCodeMatchesUrl": "https://aka.ms/github-copilot-match-public-code",
+    "manageSettingsUrl": "https://aka.ms/github-copilot-settings",
+    "managePlanUrl": "https://aka.ms/github-copilot-manage-plan",
+    "manageOverageUrl": "https://aka.ms/github-copilot-manage-overage",
+    "upgradePlanUrl": "https://aka.ms/github-copilot-upgrade-plan",
+    "signUpUrl": "https://aka.ms/github-sign-up",
+    "provider": {
+      "default": {
+        "id": "github",
+        "name": "GitHub"
+      },
+      "enterprise": {
+        "id": "github-enterprise",
+        "name": "GHE.com"
+      },
+      "google": {
+        "id": "google",
+        "name": "Google"
+      },
+      "apple": {
+        "id": "apple",
+        "name": "Apple"
+      }
+    },
+    "providerExtensionId": "vscode.github-authentication",
+    "providerUriSetting": "github-enterprise.uri",
+    "providerScopes": [
+      [
+        "read:user",
+        "user:email",
+        "repo",
+        "workflow"
+      ],
+      [
+        "user:email"
+      ],
+      [
+        "read:user"
+      ]
+    ],
+    "entitlementUrl": "https://api.github.com/copilot_internal/user",
+    "entitlementSignupLimitedUrl": "https://api.github.com/copilot_internal/subscribe_limited_user",
+    "chatQuotaExceededContext": "github.copilot.chat.quotaExceeded",
+    "completionsQuotaExceededContext": "github.copilot.completions.quotaExceeded",
+    "walkthroughCommand": "github.copilot.open.walkthrough",
+    "completionsMenuCommand": "github.copilot.toggleStatusMenu",
+    "completionsRefreshTokenCommand": "github.copilot.signIn",
+    "chatRefreshTokenCommand": "github.copilot.refreshToken",
+    "generateCommitMessageCommand": "github.copilot.git.generateCommitMessage",
+    "resolveMergeConflictsCommand": "github.copilot.git.resolveMergeConflicts",
+    "completionsAdvancedSetting": "github.copilot.advanced",
+    "completionsEnablementSetting": "github.copilot.enable",
+    "nextEditSuggestionsSetting": "github.copilot.nextEditSuggestions.enabled",
+    "tokenEntitlementUrl": "https://api.github.com/copilot_internal/v2/token",
+    "mcpRegistryDataUrl": "https://api.github.com/copilot/mcp_registry"
+  },
+  "trustedExtensionAuthAccess": [
+    "vscode.git",
+    "vscode.github",
+    "github.vscode-pull-request-github",
+    "github.copilot",
+    "github.copilot-chat"
+  ],
+  "enableTelemetry": true,
+  "quality": "stable",
+  "codeServerVersion": "4.115.0",
+  "documentationUrl": "https://go.microsoft.com/fwlink/?LinkID=533484#vscode",
+  "keyboardShortcutsUrlMac": "https://go.microsoft.com/fwlink/?linkid=832143",
+  "keyboardShortcutsUrlLinux": "https://go.microsoft.com/fwlink/?linkid=832144",
+  "keyboardShortcutsUrlWin": "https://go.microsoft.com/fwlink/?linkid=832145",
+  "introductoryVideosUrl": "https://go.microsoft.com/fwlink/?linkid=832146",
+  "tipsAndTricksUrl": "https://go.microsoft.com/fwlink/?linkid=852118",
+  "newsletterSignupUrl": "https://www.research.net/r/vsc-newsletter",
+  "linkProtectionTrustedDomains": [
+    "https://open-vsx.org"
+  ],
+  "aiConfig": {
+    "ariaKey": "code-server"
+  },
+  "commit": "1c6fb2dc200eb57c5c7d612004e18a5e6ae8b0ed",
+  "date": "2026-04-07T22:04:57Z",
+  "version": "1.115.0",
+  "extensionAllowedProposedApi": [
+    "github.copilot",
+    "github.copilot-chat"
+  ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     volumes:
       - ${CODER_DATA_PATH:-/mnt/nas-56/code-server}:/home/coder
       - ${WORKSPACE_PATH:-/mnt/nas-56/kushin77/applications/code-server-enterprise}:/home/coder/workspace
+      - ./config/product-patch.json:/usr/lib/code-server/lib/vscode/product.json:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
       interval: 30s


### PR DESCRIPTION
## Problem
Copilot Chat model picker was non-functional in code-server (model selection panel empty after clicking 'Copilot Models').

## Root Cause
product.json shipped by code-server 4.115.0 does not include extensionAllowedProposedApi. Without this, VS Code denies proposed API access to all extensions, blocking Copilot Chat's 30+ enabledApiProposals (languageModelToolSupportsModel, chatParticipantAdditions, defaultChatParticipant, etc.) that power the model selection UI.

## Fix
- Added extensionAllowedProposedApi: [github.copilot, github.copilot-chat] to a patched product.json
- Mounts config/product-patch.json over the container built-in file as read-only volume
- Survives container recreate without image rebuild

## Files Changed
- config/product-patch.json -- patched product.json with proposed API allowlist
- docker-compose.yml -- added volume mount for the patch

Fixes on-prem ide.kushnir.cloud Copilot model selection