### PR TITLE
feat(portal): route kushnir.cloud to Appsmith CE admin portal (#324)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -80,8 +80,7 @@ kushnir.cloud {
         }
     }
 
-    # All other requests: forward_auth via oauth2-proxy, then proxy to portal service
-    # Portal service should be Appsmith or Backstage (configure via COMPOSE_PROFILES or add to main compose)
+    # All other requests: forward_auth via oauth2-proxy, then proxy to Appsmith admin portal
     forward_auth oauth2-proxy:4180 {
         uri /oauth2/auth
         copy_headers X-Auth-Request-User X-Auth-Request-Email
@@ -90,10 +89,15 @@ kushnir.cloud {
     reverse_proxy appsmith:80 {
         header_up X-WEBAUTH-USER {http.reverse_proxy.header.X-Auth-Request-Email}
         header_up Host {host}
+        transport http {
+            dial_timeout 10s
+            read_timeout 0
+            write_timeout 0
+        }
     }
 
-    # Fallback: if appsmith not running, serve placeholder
+    # Fallback: if Appsmith not running, start with: COMPOSE_PROFILES=portal docker compose up -d appsmith
     handle_errors 502 503 {
-        respond "Portal service not running. Configure Appsmith/Backstage and add to docker-compose." 503
+        respond "Admin portal (Appsmith) not running. Start: COMPOSE_PROFILES=portal docker compose up -d appsmith" 503
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,31 @@ services:
         max-size: "50m"
         max-file: "10"
 
+  # ─── Appsmith (portal profile) ─────────────────────────────────────────────
+  # Admin portal — service catalog, automation triggers, user management
+  # Deploy: COMPOSE_PROFILES=portal docker compose up -d
+  # ADR: docs/adr/008-portal-platform-appsmith-vs-backstage.md
+  appsmith:
+    image: appsmith/appsmith-ce:v1.47
+    profiles: [portal]
+    container_name: appsmith
+    restart: unless-stopped
+    environment:
+      - APPSMITH_SIGNUP_DISABLED=true
+      - APPSMITH_OAUTH2_GITHUB_CLIENT_ID=${GITHUB_OAUTH_CLIENT_ID:-}
+      - APPSMITH_OAUTH2_GITHUB_CLIENT_SECRET=${GITHUB_OAUTH_CLIENT_SECRET:-}
+    expose:
+      - "80"
+    volumes:
+      - appsmith-data:/appsmith-stacks
+    networks:
+      - enterprise
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
 volumes:
   coder-data:
     driver: local
@@ -150,6 +175,8 @@ volumes:
   caddy-data:
     driver: local
   caddy-config:
+    driver: local
+  appsmith-data:
     driver: local
 
 networks:


### PR DESCRIPTION
Restores Appsmith CE under portal compose profile and wires kushnir.cloud in Caddyfile.

## Changes
- docker-compose.yml: Appsmith CE v1.47 service under \portal\ profile + appsmith-data volume
- Caddyfile: kushnir.cloud block → forward_auth + reverse_proxy to appsmith:80

## Deploy
\\\ash
COMPOSE_PROFILES=portal docker compose up -d appsmith
\\\

ADR: docs/adr/008-portal-platform-appsmith-vs-backstage.md

Closes #324