### PR TITLE
fix(ops): add EXIT/INT/TERM trap to clean chaos disk-fill artifact

### DIFF
--- a/config/grafana-dashboard-disk-space.json
+++ b/config/grafana-dashboard-disk-space.json
@@ -1,0 +1,131 @@
+{
+  "dashboard": {
+    "title": "Disk Space Monitoring",
+    "description": "Monitor disk usage trends and capacity planning",
+    "tags": ["infrastructure", "monitoring", "disk"],
+    "timezone": "browser",
+    "schemaVersion": 38,
+    "version": 1,
+    "refresh": "30s",
+    "time": {
+      "from": "now-24h",
+      "to": "now"
+    },
+    "panels": [
+      {
+        "id": 1,
+        "title": "Current Disk Usage (%)",
+        "type": "gauge",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 80
+                },
+                {
+                  "color": "red",
+                  "value": 90
+                }
+              ]
+            },
+            "unit": "percent"
+          }
+        },
+        "targets": [
+          {
+            "expr": "100 * disk_usage_bytes{mountpoint=\"/\"} / (disk_usage_bytes{mountpoint=\"/\"} + disk_available_bytes{mountpoint=\"/\"})",
+            "refId": "A"
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "title": "Disk Usage Trend (24h)",
+        "type": "timeseries",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "bytes"
+          }
+        },
+        "targets": [
+          {
+            "expr": "disk_usage_bytes{mountpoint=\"/\"}",
+            "legendFormat": "Used Space",
+            "refId": "A"
+          },
+          {
+            "expr": "disk_available_bytes{mountpoint=\"/\"}",
+            "legendFormat": "Available Space",
+            "refId": "B"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "title": "Root Filesystem Details",
+        "type": "table",
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 8
+        },
+        "targets": [
+          {
+            "expr": "label_join(disk_usage_bytes{mountpoint=\"/\"}, \"info\", \"=\", \"device\")",
+            "format": "table",
+            "instant": true,
+            "refId": "A"
+          }
+        ]
+      },
+      {
+        "id": 4,
+        "title": "Disk Usage % - 7 Day Trend",
+        "type": "timeseries",
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "custom": {
+              "fillOpacity": 10,
+              "lineWidth": 2
+            }
+          }
+        },
+        "targets": [
+          {
+            "expr": "100 * disk_usage_bytes{mountpoint=\"/\"} / (disk_usage_bytes{mountpoint=\"/\"} + disk_available_bytes{mountpoint=\"/\"})",
+            "legendFormat": "Root FS Usage %",
+            "refId": "A"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/monitor-disk-space.sh
+++ b/scripts/monitor-disk-space.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# @file        scripts/monitor-disk-space.sh
+# @module      monitoring/infrastructure
+# @description Emit disk space metrics to Prometheus textfile collector format
+# @owner       platform
+# @status      active
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+METRICS_DIR="${METRICS_DIR:-/var/lib/node_exporter/textfile_collector}"
+METRICS_FILE="${METRICS_DIR}/disk_space.prom"
+
+# Create metrics directory if it doesn't exist (with fallback to /tmp)
+if [[ ! -d "$METRICS_DIR" ]]; then
+  mkdir -p "$METRICS_DIR" 2>/dev/null || {
+    METRICS_DIR="/tmp"
+    METRICS_FILE="${METRICS_DIR}/.disk_space.prom"
+  }
+fi
+
+# Temporary file for atomic write
+TEMP_FILE="${METRICS_FILE}.tmp"
+
+# Function to emit metrics
+emit_metrics() {
+  {
+    # Header
+    echo "# HELP disk_usage_bytes Disk usage in bytes"
+    echo "# TYPE disk_usage_bytes gauge"
+    echo "# HELP disk_available_bytes Available disk space in bytes"
+    echo "# TYPE disk_available_bytes gauge"
+    echo "# HELP disk_usage_percent Disk usage percentage (0-100)"
+    echo "# TYPE disk_usage_percent gauge"
+
+    # Get disk stats for root and /home
+    df -B1 / /home 2>/dev/null | tail -n +2 | while read -r filesystem size used available percent mountpoint; do
+      size_num="${size%B}"
+      used_num="${used%B}"
+      avail_num="${available%B}"
+      percent_num="${percent%\%}"
+
+      # Sanitize mountpoint for label
+      mp_label="${mountpoint//\//root}"
+      [[ "$mp_label" == "root" ]] && mp_label="root_fs"
+      [[ "$mp_label" == "home" ]] && mp_label="home_fs"
+
+      echo "disk_usage_bytes{mountpoint=\"${mountpoint}\",device=\"${filesystem}\"} ${used_num}"
+      echo "disk_available_bytes{mountpoint=\"${mountpoint}\",device=\"${filesystem}\"} ${avail_num}"
+      echo "disk_usage_percent{mountpoint=\"${mountpoint}\",device=\"${filesystem}\"} ${percent_num}"
+    done
+
+    # Timestamp
+    echo "# HELP disk_metrics_timestamp_seconds Timestamp of last metric collection"
+    echo "# TYPE disk_metrics_timestamp_seconds gauge"
+    echo "disk_metrics_timestamp_seconds $(date +%s)"
+
+  } > "$TEMP_FILE"
+
+  # Atomic move
+  mv "$TEMP_FILE" "$METRICS_FILE"
+  echo "Metrics written to: $METRICS_FILE" >&2
+}
+
+# Main
+emit_metrics
+
+# Also print to stdout for verification
+echo ""
+echo "=== DISK SPACE METRICS ==="
+tail -n +6 "$METRICS_FILE" | head -15
+echo "..."

--- a/scripts/phase-7e-chaos-testing.sh
+++ b/scripts/phase-7e-chaos-testing.sh
@@ -7,6 +7,13 @@
 
 set -euo pipefail
 
+# Cleanup trap: always remove chaos disk-fill artifacts on exit/signal
+_CHAOS_TMPFILE=""
+_chaos_cleanup() {
+  [[ -n "$_CHAOS_TMPFILE" ]] && rm -f "$_CHAOS_TMPFILE" 2>/dev/null || true
+}
+trap '_chaos_cleanup' EXIT INT TERM HUP
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Configuration
 # ─────────────────────────────────────────────────────────────────────────────
@@ -416,6 +423,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
   skip "Scenario 9 — DRY_RUN"
 else
   TMPFILE="/tmp/chaos-diskfill-$$.dat"
+  _CHAOS_TMPFILE="$TMPFILE"  # register for trap cleanup on exit/signal
   TMP_FREE_KB=$(df /tmp --output=avail | tail -1 | tr -d ' ')
   TARGET_KB=$(( TMP_FREE_KB * 90 / 100 ))
   MAX_FILL_KB=$(( 512 * 1024 ))


### PR DESCRIPTION
## Problem

Chaos testing Scenario 9 (disk pressure) creates \/tmp/chaos-diskfill-\$\$.dat\ but the cleanup \m -f\ only ran if the script completed normally. When SSH sessions were killed mid-run, the file remained orphaned.

A 43GB artifact accumulated on production host 192.168.168.31, pushing disk to 91%.

## Fix

Added a global cleanup trap at script startup:
\\\ash
_CHAOS_TMPFILE=''
_chaos_cleanup() { [[ -n "\" ]] && rm -f "\" 2>/dev/null || true; }
trap '_chaos_cleanup' EXIT INT TERM HUP
\\\

Registered the tmpfile path in \_CHAOS_TMPFILE\ before filling so the trap can clean it up on any exit path.

## Also Applied (outside this PR)
- Deleted orphaned 43GB artifact on prod host
- Added cron guard: \