### PR TITLE
fix(scripts): adopt canonical logging + library initialization (Phase 1 dedup)

### DIFF
--- a/scripts/audit-logging.sh
+++ b/scripts/audit-logging.sh
@@ -138,7 +138,7 @@ EOF
     if echo "$json_event" >> "$AUDIT_LOG_FILE"; then
         return 0
     else
-        echo "ERROR: Failed to write to audit log" >&2
+        log_error "Failed to write to audit log at $AUDIT_LOG_FILE"
         return 1
     fi
 }

--- a/scripts/ci/admin-merge.sh
+++ b/scripts/ci/admin-merge.sh
@@ -22,8 +22,8 @@ set -euo pipefail
 # Script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source common functions
-source "$SCRIPT_DIR/../common-functions.sh"
+# Source common initialization (canonical library)
+source "$SCRIPT_DIR/../_common/init.sh"
 
 # Default values
 PR_NUMBER=""

--- a/scripts/ci/ci-merge-automation.sh
+++ b/scripts/ci/ci-merge-automation.sh
@@ -20,8 +20,8 @@ set -euo pipefail
 # Script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source common functions
-source "$SCRIPT_DIR/../common-functions.sh"
+# Source common initialization (canonical library)
+source "$SCRIPT_DIR/../_common/init.sh"
 
 # Configuration
 REPO="${REPO:-kushin77/code-server}"


### PR DESCRIPTION
Completes Phase 1 canonical library migration per deduplication analysis (#536).

## Changes
- scripts/audit-logging.sh: Replace inline echo ERROR with canonical log_error
- scripts/ci/admin-merge.sh: Migrate from deprecated common-functions.sh to _common/init.sh
- scripts/ci/ci-merge-automation.sh: Migrate from deprecated common-functions.sh to _common/init.sh

## Impact
Standardizes error handling and initialization across scripts per governance rules:
- GOV-001: No Duplication (canonical libraries)
- GOV-004: Shared Library Adoption

## Test Impact
- Zero breaking changes (interfaces unchanged)
- Dependent scripts continue to work transparently
- Error messages improved with context

Ref #536