### PR TITLE
fix(auth/ops): enforce enterprise SSO + repo scoping + profile durability

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,6 +12,10 @@ ide.kushnir.cloud, ide.kushnir.cloud:443 {
     @health path /health /healthz /ping
     respond @health "OK" 200
 
+    # Unified sign-out endpoint: clear oauth2 session and return to root SSO landing.
+    @logout path /logout /signout
+    redir @logout /oauth2/sign_out?rd=https://kushnir.cloud/ 302
+
     # oauth2-proxy endpoints must pass through directly (they ARE the auth flow)
     @oauth2 path /oauth2 /oauth2/*
     handle @oauth2 {
@@ -29,8 +33,7 @@ ide.kushnir.cloud, ide.kushnir.cloud:443 {
 }
 
 kushnir.cloud {
-    # Production posture: kushnir.cloud is the authenticated front door.
-    # All app launches originate here after oauth2-proxy authentication.
+    # Root SSO landing is always available and fronted by oauth2-proxy.
 
     encode gzip
 
@@ -45,6 +48,10 @@ kushnir.cloud {
     @health path /health /healthz /ping
     respond @health "OK" 200
 
+    # Unified sign-out endpoint: clear oauth2 session and return to root.
+    @logout path /logout /signout
+    redir @logout /oauth2/sign_out?rd=https://kushnir.cloud/ 302
+
     # oauth2-proxy control plane endpoints
     @oauth2 path /oauth2 /oauth2/*
     handle @oauth2 {
@@ -54,22 +61,17 @@ kushnir.cloud {
         }
     }
 
-    # Convenience launch path for IDE from the portal
-    redir /ide https://ide.kushnir.cloud 302
+    # Convenience deep link to IDE app.
+    redir /ide https://ide.kushnir.cloud/ 302
 
-    # Authenticated portal traffic flows through dedicated portal oauth2-proxy
-    reverse_proxy oauth2-proxy-portal:4181 {
+    # Root remains SSO protected and reachable even without optional portal profile.
+    reverse_proxy oauth2-proxy:4180 {
         header_up Host {host}
         header_up X-Real-IP {remote_host}
     }
-
-    # Fallback if portal auth/app is not running
-    handle_errors {
-        respond "Admin portal (Appsmith) not running. Start: COMPOSE_PROFILES=portal docker compose up -d appsmith" 503
-    }
 }
 
-# Locked wildcard policy: all unexpected subdomains require auth and expose no app surface.
+# Blanket SSO policy for all subdomains under kushnir.cloud.
 *.kushnir.cloud {
     encode gzip
 
@@ -81,5 +83,22 @@ kushnir.cloud {
         -Server
     }
 
-    respond "Subdomain not configured" 404
+    @health path /health /healthz /ping
+    respond @health "OK" 200
+
+    @logout path /logout /signout
+    redir @logout /oauth2/sign_out?rd=https://kushnir.cloud/ 302
+
+    @oauth2 path /oauth2 /oauth2/*
+    handle @oauth2 {
+        reverse_proxy oauth2-proxy:4180 {
+            header_up Host {host}
+            header_up X-Real-IP {remote_host}
+        }
+    }
+
+    reverse_proxy oauth2-proxy:4180 {
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+    }
 }

--- a/Caddyfile.production
+++ b/Caddyfile.production
@@ -106,6 +106,10 @@ ide.kushnir.cloud {
     respond @health_check "OK\n" 200 {
         header Content-Type "text/plain; charset=UTF-8"
     }
+
+    # Unified sign-out endpoint.
+    @logout path /logout /signout
+    redir @logout /oauth2/sign_out?rd=https://ide.kushnir.cloud/ 302
     
     # All other traffic goes through OAuth2-Proxy → Code-Server
     # OAuth2-Proxy handles authentication before forwarding
@@ -191,8 +195,23 @@ ide.kushnir.cloud {
     header X-Content-Type-Options "nosniff"
     header X-Frame-Options "DENY"
     
-    # Default response for wildcard
-    respond "Subdomain not configured" 404
+    # Blanket SSO for wildcard tenant hosts.
+    @oauth2 path /oauth2 /oauth2/*
+    handle @oauth2 {
+        reverse_proxy oauth2-proxy:4180 {
+            header_up X-Real-IP {remote_host}
+            header_up X-Forwarded-For {remote_host}
+            header_up X-Forwarded-Proto https
+            header_up X-Forwarded-Host {host}
+        }
+    }
+
+    reverse_proxy oauth2-proxy:4180 {
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto https
+        header_up X-Forwarded-Host {host}
+    }
     
     log {
         format json

--- a/README.md
+++ b/README.md
@@ -67,6 +67,47 @@ docker compose up -d
 
 For AI or observability in production, use the same profile flags from `Quick Start` on host `192.168.168.31`.
 
+## Profile Persistence And Backups
+
+code-server user state is persisted across logins, container recreation, and image upgrades.
+
+- Primary persistence: Docker volume mounted at `/home/coder`
+- User profile path: `/home/coder/.local/share/code-server/User`
+- Extensions path: `/home/coder/.local/share/code-server/extensions`
+- Backup service: `code-server-profile-backup`
+- Backup cadence: every 6 hours
+- Retention: 30 days
+
+### Verify Runtime Persistence
+
+Run on production host:
+
+```bash
+ssh akushnir@192.168.168.31
+cd code-server-enterprise
+docker compose ps --format 'table {{.Names}}\t{{.Status}}' | egrep '^(code-server|code-server-profile-backup)\s'
+docker exec code-server ls -la /home/coder/.local/share/code-server/User | head -20
+```
+
+### Restore A Profile Backup
+
+```bash
+ssh akushnir@192.168.168.31
+docker run --rm -v code-server-enterprise_code-server-profile-backups:/backups alpine:3.20 ls -la /backups
+docker run --rm \
+	-v code-server-enterprise_code-server-data:/target \
+	-v code-server-enterprise_code-server-profile-backups:/backups \
+	alpine:3.20 \
+	sh -lc 'tar -xzf /backups/code-server-user-profile-YYYYMMDD-HHMMSS.tgz -C /target'
+```
+
+After restore:
+
+```bash
+cd code-server-enterprise
+docker compose up -d --force-recreate code-server
+```
+
 ## Architecture
 
 See [ARCHITECTURE.md](ARCHITECTURE.md), [ADR index](docs/adr/README.md), and [Cloudflare tunnel ADR](docs/adr/006-cloudflare-tunnel-architecture.md).

--- a/config/developer-restrictions.sh
+++ b/config/developer-restrictions.sh
@@ -70,6 +70,33 @@ alias logs='tail -f /var/log/*.log 2>/dev/null || echo "No logs readable"'
 git() {
     # Log the git operation
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] GIT: $*" >> "$DEVELOPER_SESSION_LOG"
+
+    local repo_url=""
+    local repo_owner=""
+
+    case "$1" in
+        clone)
+            repo_url="$2"
+            ;;
+        remote)
+            if [ "$2" = "add" ] || [ "$2" = "set-url" ]; then
+                repo_url="$4"
+            fi
+            ;;
+        submodule)
+            if [ "$2" = "add" ]; then
+                repo_url="$3"
+            fi
+            ;;
+    esac
+
+    if [ -n "$repo_url" ]; then
+        repo_owner="$(_extract_github_owner_from_url "$repo_url")"
+        if ! _is_allowed_github_owner "$repo_owner"; then
+            echo "ACCESS DENIED: repository owner '$repo_owner' is not in ALLOWED_GITHUB_OWNERS=$ALLOWED_GITHUB_OWNERS"
+            return 1
+        fi
+    fi
     
     # Allow git operations (credential helper will handle SSH key access)
     command git "$@"
@@ -164,6 +191,38 @@ session_remaining() {
 # GIT Configuration for proxy
 export GIT_PROXY_HOST="${GIT_PROXY_HOST:-git-proxy.ide.kushnir.cloud}"
 export GIT_CREDENTIAL_CACHE_DAEMON_TIMEOUT=3600  # 1 hour
+export ALLOWED_GITHUB_OWNERS="${ALLOWED_GITHUB_OWNERS:-kushin77}"
+
+_extract_github_owner_from_url() {
+    local url="$1"
+
+    if [[ "$url" =~ ^https://github.com/([^/]+)/[^/]+(\.git)?$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+
+    if [[ "$url" =~ ^git@github.com:([^/]+)/[^/]+(\.git)?$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+
+    echo ""
+}
+
+_is_allowed_github_owner() {
+    local owner="$1"
+    local item
+
+    [ -z "$owner" ] && return 0
+
+    IFS=',' read -r -a _owners <<< "$ALLOWED_GITHUB_OWNERS"
+    for item in "${_owners[@]}"; do
+        item="${item//[[:space:]]/}"
+        [ "$owner" = "$item" ] && return 0
+    done
+
+    return 1
+}
 
 # Cloudflare Access Token (set via environment at login)
 # This is injected by the authentication system
@@ -179,6 +238,9 @@ export PIP_INDEX_URL="${PIP_INDEX_URL:-https://pypi.org/simple}"
 
 # Create session log file
 mkdir -p "$(dirname "$DEVELOPER_SESSION_LOG")" 2>/dev/null || true
+
+# Include repo path in credential lookups so proxy can authorize per repository.
+command git config --global credential.useHttpPath true >/dev/null 2>&1 || true
 
 # Log session start
 {

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -152,6 +152,10 @@ services:
       OAUTH2_PROXY_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       OAUTH2_PROXY_REDIRECT_URL: "https://${DOMAIN}/oauth2/callback"
       OAUTH2_PROXY_COOKIE_SECRET: ${OAUTH2_PROXY_COOKIE_SECRET}
+      OAUTH2_PROXY_EMAIL_DOMAINS: ${OAUTH2_ALLOWED_EMAIL_DOMAIN:-bioenergystrategies.com}
+      OAUTH2_PROXY_SESSION_STORE_TYPE: redis
+      OAUTH2_PROXY_REDIS_CONNECTION_URL: redis://redis:6379
+      OAUTH2_PROXY_UPSTREAMS: http://code-server:8080/
       
       # Production Security Settings
       OAUTH2_PROXY_COOKIE_SECURE: "true"
@@ -353,7 +357,6 @@ services:
       PASSWORD: ${CODE_SERVER_PASSWORD}
       SUDO_PASSWORD: ${CODE_SERVER_PASSWORD}
       NODE_OPTIONS: "--enable-source-maps --max-old-space-size=4000"
-      GITHUB_TOKEN: ${VAULT_GITHUB_TOKEN}
       OLLAMA_ENDPOINT: "http://ollama:11434"
       
       # Observability
@@ -385,6 +388,36 @@ services:
       options:
         max-size: "100m"
         labels: "service=code-server,tier=application"
+
+  code-server-profile-backup:
+    image: alpine:3.20
+    container_name: code-server-profile-backup
+    restart: always
+    networks:
+      - enterprise
+    depends_on:
+      - code-server
+    volumes:
+      - ${CODER_DATA_PATH:-/mnt/nas-56/code-server}:/source:ro
+      - /data/code-server-profile-backups:/backups
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        mkdir -p /backups
+        while true; do
+          ts="$$(date +%Y%m%d-%H%M%S)"
+          out="/backups/code-server-user-profile-$$ts.tgz"
+          tar -czf "$$out" -C /source .local/share/code-server/User || true
+          find /backups -type f -name 'code-server-user-profile-*.tgz' -mtime +30 -delete || true
+          sleep 21600
+        done
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        labels: "service=code-server-profile-backup,tier=operations"
 
   ollama:
     image: ollama/ollama:0.1.27

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
       - ITEM_URL=https://open-vsx.org/vscode/item
       - CS_DISABLE_FILE_DOWNLOADS=false
       - NODE_OPTIONS=--enable-source-maps
-      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       - OLLAMA_ENDPOINT=http://ollama:11434
       - OLLAMA_DEFAULT_MODEL=llama2:7b-chat
       - NODE_TLS_REJECT_UNAUTHORIZED=0
@@ -169,10 +168,12 @@ services:
       OAUTH2_PROXY_COOKIE_SECRET: "${OAUTH2_PROXY_COOKIE_SECRET}"
       OAUTH2_PROXY_PROVIDER: "google"
       OAUTH2_PROXY_OIDC_ISSUER_URL: "https://accounts.google.com"
-      OAUTH2_PROXY_REDIRECT_URL: "https://${DOMAIN:-192.168.168.31}/oauth2/callback"
+      OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_REDIRECT_URL:-https://ide.kushnir.cloud/oauth2/callback}"
       OAUTH2_PROXY_UPSTREAMS: "http://code-server:8080/"
-      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      OAUTH2_PROXY_EMAIL_DOMAINS: "${OAUTH2_ALLOWED_EMAIL_DOMAIN:-bioenergystrategies.com}"
       OAUTH2_PROXY_AUTHENTICATED_EMAILS_FILE: "/etc/oauth2-proxy/allowed-emails.txt"
+      OAUTH2_PROXY_SESSION_STORE_TYPE: "redis"
+      OAUTH2_PROXY_REDIS_CONNECTION_URL: "redis://redis:6379"
       OAUTH2_PROXY_COOKIE_NAME: "_oauth2_proxy_ide"
       OAUTH2_PROXY_COOKIE_SECURE: "true"
       OAUTH2_PROXY_COOKIE_HTTPONLY: "true"
@@ -185,7 +186,7 @@ services:
       OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
       OAUTH2_PROXY_PROXY_PREFIX: "/oauth2"
       OAUTH2_PROXY_PROXY_WEBSOCKETS: "true"
-      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "false"
       OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
       OAUTH2_PROXY_PASS_USER_HEADERS: "true"
       OAUTH2_PROXY_PASS_BASIC_AUTH: "false"
@@ -231,10 +232,12 @@ services:
       OAUTH2_PROXY_COOKIE_SECRET: "${OAUTH2_PROXY_COOKIE_SECRET}"
       OAUTH2_PROXY_PROVIDER: "google"
       OAUTH2_PROXY_OIDC_ISSUER_URL: "https://accounts.google.com"
-      OAUTH2_PROXY_REDIRECT_URL: "https://ide.kushnir.cloud/oauth2/callback"
+      OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_REDIRECT_URL:-https://ide.kushnir.cloud/oauth2/callback}"
       OAUTH2_PROXY_UPSTREAMS: "http://appsmith:80/"
-      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      OAUTH2_PROXY_EMAIL_DOMAINS: "${OAUTH2_ALLOWED_EMAIL_DOMAIN:-bioenergystrategies.com}"
       OAUTH2_PROXY_AUTHENTICATED_EMAILS_FILE: "/etc/oauth2-proxy/allowed-emails.txt"
+      OAUTH2_PROXY_SESSION_STORE_TYPE: "redis"
+      OAUTH2_PROXY_REDIS_CONNECTION_URL: "redis://redis:6379"
       OAUTH2_PROXY_COOKIE_NAME: "_oauth2_proxy_ide"
       OAUTH2_PROXY_COOKIE_SECURE: "true"
       OAUTH2_PROXY_COOKIE_HTTPONLY: "true"
@@ -247,7 +250,7 @@ services:
       OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4181"
       OAUTH2_PROXY_PROXY_PREFIX: "/oauth2"
       OAUTH2_PROXY_PROXY_WEBSOCKETS: "true"
-      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "false"
       OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
       OAUTH2_PROXY_PASS_USER_HEADERS: "true"
       OAUTH2_PROXY_PASS_BASIC_AUTH: "false"
@@ -429,6 +432,39 @@ services:
         max-file: "3"
 
   # ────────────────────────────────────────────────────────────────────────────
+  # code-server-profile-backup — periodic backup of user profile state
+  # ────────────────────────────────────────────────────────────────────────────
+  code-server-profile-backup:
+    image: alpine:3.20
+    container_name: code-server-profile-backup
+    restart: unless-stopped
+    networks:
+      - enterprise
+    depends_on:
+      - code-server
+    volumes:
+      - code-server-data:/source:ro
+      - code-server-profile-backups:/backups
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        mkdir -p /backups
+        while true; do
+          ts="$$(date +%Y%m%d-%H%M%S)"
+          out="/backups/code-server-user-profile-$$ts.tgz"
+          tar -czf "$$out" -C /source .local/share/code-server/User || true
+          find /backups -type f -name 'code-server-user-profile-*.tgz' -mtime +30 -delete || true
+          sleep 21600
+        done
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # ────────────────────────────────────────────────────────────────────────────
   # prometheus — Metrics collection and alerting engine
   # ────────────────────────────────────────────────────────────────────────────
   prometheus:
@@ -587,6 +623,12 @@ services:
       - enterprise
     environment:
       - APPSMITH_SIGNUP_DISABLED=true
+      - APPSMITH_FORM_LOGIN_DISABLED=true
+      - APPSMITH_OAUTH2_GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - APPSMITH_OAUTH2_GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - APPSMITH_BASE_URL=https://kushnir.cloud
+      - APPSMITH_CUSTOM_DOMAIN=kushnir.cloud
+      - APPSMITH_ADMIN_EMAILS=${APPSMITH_ADMIN_EMAILS:-akushnir@bioenergystrategies.com}
     expose:
       - "80"
     volumes:
@@ -619,6 +661,9 @@ networks:
 # ════════════════════════════════════════════════════════════════════════════
 volumes:
   code-server-data:
+    driver: local
+
+  code-server-profile-backups:
     driver: local
   
   # ✅ NAS-backed storage for ollama models (persistent across failover to .30)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,13 +24,14 @@ services:
       # Use strong password from .env, not defaults
       - PASSWORD=${CODE_SERVER_PASSWORD:-change-me-in-env}
       - SUDO_PASSWORD=${CODE_SERVER_PASSWORD:-change-me-in-env}
-      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       - OLLAMA_ENDPOINT=http://ollama:11434
     command:
       - "--bind-addr=0.0.0.0:8080"
       - "--disable-telemetry"
       - "--cert=false"
       - "--auth=password"
+      - "--user-data-dir=/home/coder/.local/share/code-server"
+      - "--extensions-dir=/home/coder/.local/share/code-server/extensions"
     volumes:
       - code-server-enterprise-data:/home/coder
     healthcheck:
@@ -148,7 +149,7 @@ services:
       OAUTH2_PROXY_HTTP_ADDRESS: "0.0.0.0:4180"
       OAUTH2_PROXY_PROXY_PREFIX: "/oauth2"
       OAUTH2_PROXY_PROXY_WEBSOCKETS: "true"
-      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
+      OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "false"
       OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
       OAUTH2_PROXY_PASS_USER_HEADERS: "true"
       OAUTH2_PROXY_PASS_BASIC_AUTH: "false"
@@ -206,6 +207,38 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # ─── code-server-profile-backup ───────────────────────────────────────────
+  # Periodic backup for code-server user profile state.
+  code-server-profile-backup:
+    image: alpine:3.20
+    container_name: code-server-profile-backup
+    restart: unless-stopped
+    networks:
+      - enterprise
+    depends_on:
+      - code-server
+    volumes:
+      - code-server-enterprise-data:/source:ro
+      - code-server-profile-backups:/backups
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        mkdir -p /backups
+        while true; do
+          ts="$(date +%Y%m%d-%H%M%S)"
+          out="/backups/code-server-user-profile-$ts.tgz"
+          tar -czf "$out" -C /source .local/share/code-server/User || true
+          find /backups -type f -name 'code-server-user-profile-*.tgz' -mtime +30 -delete || true
+          sleep 21600
+        done
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Networks & Volumes
 # ─────────────────────────────────────────────────────────────────────────────
@@ -218,6 +251,8 @@ networks:
 
 volumes:
   code-server-enterprise-data:
+    driver: local
+  code-server-profile-backups:
     driver: local
   ollama-data:
     driver: local

--- a/docs/CODE-SERVER-DEV-ENVIRONMENT.md
+++ b/docs/CODE-SERVER-DEV-ENVIRONMENT.md
@@ -234,6 +234,48 @@ docker exec code-server npm list -g typescript
 
 ## Design Principles
 
+## Profile Durability Runbook
+
+Profile state is designed to survive user logins, container recreation, and code-server version updates.
+
+### Persistence Layout
+
+- Home volume mount: `/home/coder`
+- User profile: `/home/coder/.local/share/code-server/User`
+- Extensions: `/home/coder/.local/share/code-server/extensions`
+- Backup volume: `code-server-enterprise_code-server-profile-backups`
+- Backup container: `code-server-profile-backup`
+
+### Validate On Host
+
+```bash
+ssh akushnir@192.168.168.31
+cd /home/akushnir/code-server-enterprise
+docker-compose ps --format 'table {{.Names}}\t{{.Status}}' | egrep '^(code-server|code-server-profile-backup)\s'
+docker exec code-server sh -lc 'ls -la /home/coder/.local/share/code-server/User | head -20'
+docker run --rm -v code-server-enterprise_code-server-profile-backups:/b alpine:3.20 ls -la /b
+```
+
+### Restore Procedure
+
+```bash
+ssh akushnir@192.168.168.31
+docker run --rm \
+  -v code-server-enterprise_code-server-data:/target \
+  -v code-server-enterprise_code-server-profile-backups:/backups \
+  alpine:3.20 \
+  sh -lc 'tar -xzf /backups/code-server-user-profile-YYYYMMDD-HHMMSS.tgz -C /target'
+
+cd /home/akushnir/code-server-enterprise
+docker-compose up -d --force-recreate code-server
+```
+
+### Notes
+
+- Restore extracts the saved `User` subtree into the persisted home volume.
+- Use the most recent backup artifact unless a point-in-time rollback is needed.
+- Keep this runbook aligned with compose template changes in `docker-compose.tpl`.
+
 ### ✅ Immutability
 
 All packages are installed during image build, not at runtime:

--- a/frontend/src/utils/session-keepalive.ts
+++ b/frontend/src/utils/session-keepalive.ts
@@ -91,9 +91,10 @@ export async function doSilentRefresh(): Promise<boolean> {
       
       // Only leader tab redirects to login (prevent multiple redirects)
       if (isLeader()) {
-        console.warn('[Session] Leader tab: redirecting to login...');
+        console.warn('[Session] Leader tab: redirecting to SSO sign-in...');
         setTimeout(() => {
-          window.location.href = '/login?reason=session-expired';
+          const loginRedirect = `/oauth2/sign_in?rd=${encodeURIComponent(window.location.href)}`;
+          window.location.href = loginRedirect;
         }, 100);
       } else {
         console.debug('[Session] Follower tab: leader will handle redirect');

--- a/scripts/git-credential-cloudflare-proxy
+++ b/scripts/git-credential-cloudflare-proxy
@@ -131,13 +131,14 @@ hash_url() {
 get_credentials() {
     local protocol="$1"
     local host="$2"
-    local url_hash=$(hash_url "${protocol}://${host}")
+    local path="$3"
+    local url_hash=$(hash_url "${protocol}://${host}${path}")
     
-    log_proxy "get" "${protocol}://${host}" "START"
+    log_proxy "get" "${protocol}://${host}${path}" "START"
     
     # Check cache first
     if cached_creds=$(get_cached_credentials "$url_hash"); then
-        log_proxy "get" "${protocol}://${host}" "CACHED"
+        log_proxy "get" "${protocol}://${host}${path}" "CACHED"
         echo "$cached_creds"
         return 0
     fi
@@ -146,12 +147,12 @@ get_credentials() {
     local response=$(curl -s -X POST \
         -H "Authorization: Bearer ${CLOUDFLARE_ACCESS_TOKEN}" \
         -H "Content-Type: application/json" \
-        -d "{\"protocol\":\"$protocol\",\"host\":\"$host\"}" \
+        -d "{\"protocol\":\"$protocol\",\"host\":\"$host\",\"path\":\"$path\"}" \
         "${GIT_PROXY_PROTOCOL}://${GIT_PROXY_HOST}:${GIT_PROXY_PORT}/git-creds/get" \
         2>/dev/null || echo "")
     
     if [ -z "$response" ]; then
-        log_proxy "get" "${protocol}://${host}" "ERROR (no response from proxy)"
+        log_proxy "get" "${protocol}://${host}${path}" "ERROR (no response from proxy)"
         echo "protocol=$protocol"
         echo "host=$host"
         return 1
@@ -160,36 +161,38 @@ get_credentials() {
     # Cache the credentials
     cache_credentials "$url_hash" "$response"
     
-    log_proxy "get" "${protocol}://${host}" "SUCCESS"
+    log_proxy "get" "${protocol}://${host}${path}" "SUCCESS"
     echo "$response"
 }
 
 store_credentials() {
     local protocol="$1"
     local host="$2"
-    local username="$3"
-    local password="$4"
-    local url_hash=$(hash_url "${protocol}://${host}")
+    local path="$3"
+    local username="$4"
+    local password="$5"
+    local url_hash=$(hash_url "${protocol}://${host}${path}")
     
-    log_proxy "store" "${protocol}://${host}" "START"
+    log_proxy "store" "${protocol}://${host}${path}" "START"
     
     # Send to proxy server (not really storing passwords, just forwarding for audit)
     curl -s -X POST \
         -H "Authorization: Bearer ${CLOUDFLARE_ACCESS_TOKEN}" \
         -H "Content-Type: application/json" \
-        -d "{\"protocol\":\"$protocol\",\"host\":\"$host\",\"username\":\"$username\"}" \
+        -d "{\"protocol\":\"$protocol\",\"host\":\"$host\",\"path\":\"$path\",\"username\":\"$username\"}" \
         "${GIT_PROXY_PROTOCOL}://${GIT_PROXY_HOST}:${GIT_PROXY_PORT}/git-creds/store" \
         2>/dev/null || true
     
-    log_proxy "store" "${protocol}://${host}" "RECORDED"
+    log_proxy "store" "${protocol}://${host}${path}" "RECORDED"
 }
 
 erase_credentials() {
     local protocol="$1"
     local host="$2"
-    local url_hash=$(hash_url "${protocol}://${host}")
+    local path="$3"
+    local url_hash=$(hash_url "${protocol}://${host}${path}")
     
-    log_proxy "erase" "${protocol}://${host}" "START"
+    log_proxy "erase" "${protocol}://${host}${path}" "START"
     
     # Clear cache
     rm -f "${CRED_CACHE_DIR}/${url_hash}.cache"
@@ -198,11 +201,11 @@ erase_credentials() {
     curl -s -X POST \
         -H "Authorization: Bearer ${CLOUDFLARE_ACCESS_TOKEN}" \
         -H "Content-Type: application/json" \
-        -d "{\"protocol\":\"$protocol\",\"host\":\"$host\"}" \
+        -d "{\"protocol\":\"$protocol\",\"host\":\"$host\",\"path\":\"$path\"}" \
         "${GIT_PROXY_PROTOCOL}://${GIT_PROXY_HOST}:${GIT_PROXY_PORT}/git-creds/erase" \
         2>/dev/null || true
     
-    log_proxy "erase" "${protocol}://${host}" "SUCCESS"
+    log_proxy "erase" "${protocol}://${host}${path}" "SUCCESS"
 }
 
 # ==================== MAIN CREDENTIAL HELPER INTERFACE ====================
@@ -234,6 +237,7 @@ chmod 700 "$CRED_CACHE_DIR" 2>/dev/null || true
 # Parse input from git
 protocol=""
 host=""
+path=""
 username=""
 password=""
 
@@ -241,6 +245,7 @@ while IFS='=' read -r key value; do
     case "$key" in
         protocol) protocol="$value" ;;
         host) host="$value" ;;
+        path) path="$value" ;;
         username) username="$value" ;;
         password) password="$value" ;;
     esac
@@ -248,13 +253,13 @@ done
 
 case "$operation" in
     get)
-        get_credentials "$protocol" "$host"
+        get_credentials "$protocol" "$host" "$path"
         ;;
     store)
-        store_credentials "$protocol" "$host" "$username" "$password"
+        store_credentials "$protocol" "$host" "$path" "$username" "$password"
         ;;
     erase)
-        erase_credentials "$protocol" "$host"
+        erase_credentials "$protocol" "$host" "$path"
         ;;
     *)
         log_proxy "operation:$operation" "${protocol}://${host}" "ERROR (unknown operation)"


### PR DESCRIPTION
## Summary
Implements enterprise hardening for SSO/logout consistency, repository access scoping, and user profile durability.

## Changes
- Caddy routing hardening:
  - unified `/logout`/`/signout` redirects through oauth2 sign-out
  - `kushnir.cloud` root now always SSO-fronted by `oauth2-proxy`
  - wildcard `*.kushnir.cloud` now follows blanket SSO proxy policy (no anonymous 404 surface)
- Frontend session UX hardening:
  - session-expiry redirect now uses `/oauth2/sign_in?rd=...` instead of local `/login`
- Repo authorization controls:
  - `config/developer-restrictions.sh` now enforces `ALLOWED_GITHUB_OWNERS` gate for clone/remote/submodule URLs
  - sets `credential.useHttpPath=true` to enable per-repo auth decisions
  - `scripts/git-credential-cloudflare-proxy` now forwards `path` to proxy APIs (`get/store/erase`) and includes it in cache keys/logs
- Compose auth hardening + persistence:
  - remove broad shared `GITHUB_TOKEN` injection from code-server service definitions
  - tighten oauth email-domain policy via `OAUTH2_ALLOWED_EMAIL_DOMAIN`
  - enable oauth2 Redis session store (`OAUTH2_PROXY_SESSION_STORE_TYPE=redis`)
  - add `code-server-profile-backup` sidecar with 6h backups + 30d retention
  - fixed compose interpolation bug in backup command by escaping shell vars (`$$`)

## Files
- `Caddyfile`
- `Caddyfile.production`
- `frontend/src/utils/session-keepalive.ts`
- `config/developer-restrictions.sh`
- `scripts/git-credential-cloudflare-proxy`
- `docker-compose.yml`
- `docker-compose.production.yml`
- `docker/docker-compose.yml`

## Runtime Verification (on 192.168.168.31)
- Recreated impacted services: `redis`, `oauth2-proxy`, `caddy`, `code-server-profile-backup`
- Verified backup sidecar up and artifact generation:
  - `code-server-user-profile-20260417-193448.tgz`
- Verified ide/root logout endpoint behavior over HTTPS with SNI (`curl --resolve ...`).

## Known Caveat (tracked)
- Arbitrary wildcard host HTTPS (`test.kushnir.cloud`) still depends on cert/SNI coverage; route policy is now auth-gated, but wildcard DNS/certificate issuance must be validated in production DNS/ACME path.

## Why
Closes high-priority enterprise gaps:
1. logout should cleanly exit to SSO
2. user profile changes should persist with recoverability
3. SSO policy should blanket subdomains
4. repo visibility/access should be owner-scoped at shell/proxy boundary
5. additional enterprise auth/ops hardening completed