### PR TITLE
feat(governance): add blocking global dedup guard and SSOT policy (#578)

### DIFF
--- a/.github/workflows/global-dedup-guard.yml
+++ b/.github/workflows/global-dedup-guard.yml
@@ -1,0 +1,42 @@
+name: Global Dedup Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "docker-compose*.yml"
+      - "Caddyfile*"
+      - "main.tf"
+      - "terraform/**"
+      - "scripts/**"
+      - "docs/**"
+      - "config/**"
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+    paths:
+      - "docker-compose*.yml"
+      - "Caddyfile*"
+      - "main.tf"
+      - "terraform/**"
+      - "scripts/**"
+      - "docs/**"
+      - "config/**"
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  dedup-ssot-enforcement:
+    name: Dedup + SSOT Enforcement
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Enforce global dedup guard
+        run: bash scripts/ci/enforce-global-dedup.sh

--- a/docs/governance/GLOBAL-DEDUP-GOVERNANCE.md
+++ b/docs/governance/GLOBAL-DEDUP-GOVERNANCE.md
@@ -1,0 +1,69 @@
+# Global Dedup Governance
+
+Version: 1.0  
+Effective: 2026-04-17  
+Owner: Platform Engineering
+
+## Purpose
+
+This policy eliminates overlap drift by enforcing single source of truth (SSOT) for critical infrastructure paths and blocking new duplicate variants in CI.
+
+## Canonical Sources
+
+1. Compose runtime: docker-compose.yml
+2. Caddy runtime config: Caddyfile
+3. Terraform entrypoint: terraform/main.tf
+
+## Blocked Overlap Paths
+
+These are legacy paths under freeze. They are listed for enforcement and migration tracking, not for active runtime edits.
+
+Changes to these files are blocked by default in CI unless a documented waiver is used:
+
+1. docker/docker-compose.yml
+2. scripts/docker-compose.yml
+3. docker-compose.production.yml
+4. docker-compose.prod.yml
+5. docker-compose.base.yml
+6. docker-compose.dev.yml
+7. Caddyfile.production
+8. Caddyfile.tpl
+
+Waiver control:
+
+1. Set ALLOW_LEGACY_OVERLAP_EDIT=true in CI only when required.
+2. Link waiver rationale in PR body and governance waiver issue.
+3. Include rollback and migration plan back to canonical paths.
+
+## Global Rules
+
+1. No new top-level compose variants beyond docker-compose.yml.
+2. No new Caddyfile variants beyond Caddyfile.
+3. Keep main.tf and terraform/main.tf synchronized whenever either mirror is changed.
+4. OAuth callback settings must be centralized using OAUTH2_REDIRECT_URL in docker-compose.yml.
+5. New documentation files under docs/ must not create normalized filename collisions with existing docs.
+
+## Enforcement
+
+CI workflow:
+
+1. .github/workflows/global-dedup-guard.yml
+
+Guard script:
+
+1. scripts/ci/enforce-global-dedup.sh
+
+## Local Validation
+
+Run before opening a PR:
+
+```bash
+bash scripts/ci/enforce-global-dedup.sh
+```
+
+## Migration Roadmap
+
+1. Freeze overlap-prone legacy files (current phase).
+2. Move all active changes to canonical files only.
+3. Retire duplicated mirrors once no workflows/scripts depend on them.
+4. Remove waiver path after legacy removal is complete.

--- a/docs/governance/GLOBAL-DEDUP-TRIAGE.md
+++ b/docs/governance/GLOBAL-DEDUP-TRIAGE.md
@@ -1,0 +1,116 @@
+# Global Dedup Triage
+
+Version: 1.0  
+Date: 2026-04-17  
+Owner: Platform Engineering
+
+## Objective
+
+Identify overlap clusters across the repository and define executable removal order toward strict single-source-of-truth governance.
+
+## Triage Summary
+
+1. Critical overlap cluster: compose variants and runtime drift risk.
+2. Critical overlap cluster: Caddyfile variants and callback/auth behavior drift.
+3. High overlap cluster: Terraform root mirror and terraform/ mirror.
+4. High overlap cluster: duplicated/near-duplicated docs and naming collisions.
+5. Medium overlap cluster: overlapping governance scripts/workflows with advisory-only behavior.
+
+## Cluster Details
+
+### 1) Compose Overlap
+
+Risk:
+
+1. Multiple compose variants can diverge from runtime behavior and reintroduce auth regressions.
+
+Current state:
+
+1. Canonical runtime: docker-compose.yml.
+2. Overlap-prone legacy variants are now blocked by CI guard for routine edits.
+
+Removal actions:
+
+1. Freeze legacy compose variants (already enforced in guard).
+2. Migrate any remaining consumers to docker-compose.yml.
+3. Archive legacy compose variants after migration validation.
+
+### 2) Caddyfile Overlap
+
+Risk:
+
+1. Callback routing and auth proxy behavior can drift between Caddyfile variants.
+
+Current state:
+
+1. Canonical runtime: Caddyfile.
+2. Legacy variants blocked by CI guard for routine edits.
+
+Removal actions:
+
+1. Keep runtime changes only in Caddyfile.
+2. Archive legacy Caddyfile variants after final dependency check.
+
+### 3) Terraform Mirror Overlap
+
+Risk:
+
+1. Parallel edits across main.tf and terraform/main.tf can create silent drift.
+
+Current state:
+
+1. Guard enforces mirror parity when either mirror file is changed.
+
+Removal actions:
+
+1. Stop introducing new root-level terraform mirrors.
+2. Transition consumers to terraform/main.tf as canonical.
+3. Decommission root mirror once callers are migrated.
+
+### 4) Documentation Overlap
+
+Risk:
+
+1. Near-duplicate docs with normalized-name collisions create contradictory guidance.
+
+Current state:
+
+1. Guard blocks newly-added docs with normalized-name collisions.
+
+Removal actions:
+
+1. Consolidate duplicate docs into canonical runbooks/ADR paths.
+2. Replace superseded docs with stubs that link to canonical source, then archive.
+
+### 5) Governance Control Overlap
+
+Risk:
+
+1. Advisory-only checks allow overlap to persist.
+
+Current state:
+
+1. New blocking workflow: .github/workflows/global-dedup-guard.yml.
+2. Enforcement script: scripts/ci/enforce-global-dedup.sh.
+
+Removal actions:
+
+1. Make dedup guard a required status check on main.
+2. Route all waivers through governance waiver issue template.
+3. Add monthly overlap-burndown metric to governance report.
+
+## Execution Order
+
+1. Enforce freeze (done).
+2. Migrate active callers to canonical paths (next).
+3. Archive deprecated overlap files.
+4. Tighten branch protection to require dedup guard.
+5. Track monthly overlap burndown until zero active overlap.
+
+## Exit Criteria
+
+1. No active non-canonical compose or Caddyfile variants changed in 30 days.
+2. No parity drift in Terraform mirror checks.
+3. No new doc name collisions.
+4. All overlap waivers closed or expired.
+5. Branch protection includes required dedup guard check.

--- a/scripts/ci/enforce-global-dedup.sh
+++ b/scripts/ci/enforce-global-dedup.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# @file        scripts/ci/enforce-global-dedup.sh
+# @module      governance/duplication
+# @description Enforce global SSOT and block overlap-prone changes in CI.
+# @owner       platform
+# @status      active
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+source "${REPO_ROOT}/scripts/_common/init.sh"
+
+cd "${REPO_ROOT}"
+
+ALLOW_LEGACY_OVERLAP_EDIT="${ALLOW_LEGACY_OVERLAP_EDIT:-false}"
+
+readonly CANONICAL_COMPOSE="docker-compose.yml"
+readonly CANONICAL_CADDYFILE="Caddyfile"
+readonly CANONICAL_TERRAFORM="terraform/main.tf"
+
+# Legacy/overlap-prone files are blocked by default in CI to prevent new drift.
+readonly BLOCKED_FILES=(
+  "docker/docker-compose.yml"
+  "scripts/docker-compose.yml"
+  "docker-compose.production.yml"
+  "docker-compose.prod.yml"
+  "docker-compose.base.yml"
+  "docker-compose.dev.yml"
+  "Caddyfile.production"
+  "Caddyfile.tpl"
+)
+
+# Some files intentionally document legacy paths and are exempt from reference checks.
+readonly REFERENCE_ALLOWLIST=(
+  "scripts/ci/enforce-global-dedup.sh"
+  "docs/governance/GLOBAL-DEDUP-GOVERNANCE.md"
+  "docs/governance/GLOBAL-DEDUP-TRIAGE.md"
+)
+
+# Determine a robust diff range for both PR and push events.
+resolve_diff_range() {
+  local base_ref=""
+
+  if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+    base_ref="origin/${GITHUB_BASE_REF}"
+  elif git show-ref --verify --quiet refs/remotes/origin/main; then
+    base_ref="origin/main"
+  fi
+
+  if [[ -n "${base_ref}" ]]; then
+    echo "${base_ref}...HEAD"
+  else
+    # Fallback for local/offline execution: scan tracked files as "changed" scope.
+    echo ""
+  fi
+}
+
+collect_changed_files() {
+  local range="$1"
+  if [[ -n "${range}" ]]; then
+    git diff --name-only "${range}" | sed '/^$/d'
+  else
+    git ls-files
+  fi
+}
+
+collect_added_files() {
+  local range="$1"
+  if [[ -n "${range}" ]]; then
+    git diff --name-status "${range}" | awk '$1 ~ /^A/ {print $2}'
+  fi
+}
+
+is_blocked_file() {
+  local f="$1"
+  local blocked
+  for blocked in "${BLOCKED_FILES[@]}"; do
+    if [[ "${f}" == "${blocked}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+is_changed_file() {
+  local needle="$1"
+  local file
+  for file in "${CHANGED_FILES[@]}"; do
+    if [[ "${file}" == "${needle}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+is_allowlisted_reference_file() {
+  local f="$1"
+  local allowed
+  for allowed in "${REFERENCE_ALLOWLIST[@]}"; do
+    if [[ "${f}" == "${allowed}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+is_archived_file() {
+  local f="$1"
+  [[ "${f}" == archived/* || "${f}" == .archived/* || "${f}" == scripts/_archive/* ]]
+}
+
+failures=0
+
+DIFF_RANGE="$(resolve_diff_range)"
+mapfile -t CHANGED_FILES < <(collect_changed_files "${DIFF_RANGE}")
+mapfile -t ADDED_FILES < <(collect_added_files "${DIFF_RANGE}")
+
+log_info "Global dedup guard started"
+log_info "Canonical compose: ${CANONICAL_COMPOSE}"
+log_info "Canonical Caddyfile: ${CANONICAL_CADDYFILE}"
+log_info "Canonical Terraform entrypoint: ${CANONICAL_TERRAFORM}"
+
+# 1) Block modifications to legacy overlap files unless explicitly waived.
+if [[ "${ALLOW_LEGACY_OVERLAP_EDIT}" != "true" ]]; then
+  for file in "${CHANGED_FILES[@]}"; do
+    if is_blocked_file "${file}"; then
+      log_error "Blocked overlap-prone file modified: ${file}"
+      log_error "Use canonical files (${CANONICAL_COMPOSE}, ${CANONICAL_CADDYFILE}, ${CANONICAL_TERRAFORM}) instead."
+      log_error "If absolutely required, rerun with ALLOW_LEGACY_OVERLAP_EDIT=true and document waiver."
+      failures=$((failures + 1))
+    fi
+  done
+fi
+
+# 2) Prevent adding new duplicate top-level compose/caddy variants.
+for file in "${ADDED_FILES[@]}"; do
+  if [[ "${file}" =~ ^docker-compose.*\.ya?ml$ ]] && [[ "${file}" != "${CANONICAL_COMPOSE}" ]]; then
+    log_error "New duplicate compose variant added: ${file}"
+    failures=$((failures + 1))
+  fi
+
+  if [[ "${file}" =~ ^Caddyfile.*$ ]] && [[ "${file}" != "${CANONICAL_CADDYFILE}" ]]; then
+    log_error "New duplicate Caddyfile variant added: ${file}"
+    failures=$((failures + 1))
+  fi
+
+done
+
+# 3) Ensure root Terraform mirror cannot drift when either mirror is changed.
+if is_changed_file "main.tf" || is_changed_file "terraform/main.tf"; then
+  if [[ -f "main.tf" && -f "terraform/main.tf" ]]; then
+    if ! cmp -s "main.tf" "terraform/main.tf"; then
+      log_error "Terraform mirror drift detected between main.tf and terraform/main.tf"
+      log_error "When changing either mirror, sync both files in the same PR."
+      failures=$((failures + 1))
+    fi
+  fi
+fi
+
+# 4) Enforce single callback variable pattern in canonical compose auth blocks.
+if [[ -f "${CANONICAL_COMPOSE}" ]]; then
+  callback_count="$(grep -c 'OAUTH2_PROXY_REDIRECT_URL:' "${CANONICAL_COMPOSE}" || true)"
+  callback_var_count="$(grep -c 'OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_REDIRECT_URL:-https://ide.kushnir.cloud/oauth2/callback}"' "${CANONICAL_COMPOSE}" || true)"
+
+  if [[ "${callback_count}" -lt 2 ]]; then
+    log_error "Expected at least 2 OAUTH2_PROXY_REDIRECT_URL entries in ${CANONICAL_COMPOSE}, found ${callback_count}"
+    failures=$((failures + 1))
+  fi
+
+  if [[ "${callback_var_count}" -lt 2 ]]; then
+    log_error "Auth callback in ${CANONICAL_COMPOSE} is not centralized via OAUTH2_REDIRECT_URL in both proxy blocks"
+    failures=$((failures + 1))
+  fi
+fi
+
+# 5) Prevent newly-added docs with normalized-name collisions in docs/.
+normalize_name() {
+  local s="$1"
+  echo "${s}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+//g'
+}
+
+if [[ "${#ADDED_FILES[@]}" -gt 0 ]]; then
+  mapfile -t EXISTING_DOCS < <(git ls-files 'docs/**/*.md' 'docs/*.md' 2>/dev/null || true)
+
+  for file in "${ADDED_FILES[@]}"; do
+    if [[ "${file}" == docs/*.md || "${file}" == docs/**/*.md ]]; then
+      added_base="$(basename "${file}")"
+      added_norm="$(normalize_name "${added_base}")"
+
+      for existing in "${EXISTING_DOCS[@]}"; do
+        if [[ "${existing}" == "${file}" ]]; then
+          continue
+        fi
+
+        existing_base="$(basename "${existing}")"
+        existing_norm="$(normalize_name "${existing_base}")"
+
+        if [[ -n "${added_norm}" && "${added_norm}" == "${existing_norm}" ]]; then
+          log_error "Documentation name collision detected: ${file} ~= ${existing}"
+          failures=$((failures + 1))
+          break
+        fi
+      done
+    fi
+  done
+fi
+
+# 6) Block new references to blocked legacy files in changed, non-archived files.
+for file in "${CHANGED_FILES[@]}"; do
+  if [[ ! -f "${file}" ]]; then
+    continue
+  fi
+
+  if is_blocked_file "${file}" || is_archived_file "${file}" || is_allowlisted_reference_file "${file}"; then
+    continue
+  fi
+
+  blocked_ref=""
+  for blocked_ref in "${BLOCKED_FILES[@]}"; do
+    if grep -Fq "${blocked_ref}" "${file}"; then
+      log_error "New/updated file references blocked legacy path: ${file} -> ${blocked_ref}"
+      log_error "Use canonical files (${CANONICAL_COMPOSE}, ${CANONICAL_CADDYFILE}, ${CANONICAL_TERRAFORM}) instead."
+      failures=$((failures + 1))
+      break
+    fi
+  done
+done
+
+if [[ "${failures}" -gt 0 ]]; then
+  log_fatal "Global dedup guard failed with ${failures} violation(s)."
+fi
+
+log_info "Global dedup guard passed"


### PR DESCRIPTION
## Summary
Adds a blocking governance guardrail to reduce overlap drift and enforce canonical SSOT paths.

## Changes
- add .github/workflows/global-dedup-guard.yml
- add scripts/ci/enforce-global-dedup.sh
- add docs/governance/GLOBAL-DEDUP-GOVERNANCE.md
- add docs/governance/GLOBAL-DEDUP-TRIAGE.md

## Enforcement Included
- blocks edits to overlap-prone legacy compose/Caddy variants unless explicit waiver
- blocks new duplicate top-level compose/Caddy variants
- enforces main.tf and terraform/main.tf mirror parity when changed
- validates centralized OAuth callback variable pattern in canonical compose
- blocks normalized-name collisions for newly added docs
- blocks new references to frozen legacy overlap paths in changed files

## Validation
- bash syntax check passed for scripts/ci/enforce-global-dedup.sh

## Notes
- Canonical sources enforced: docker-compose.yml, Caddyfile, terraform/main.tf
- Waiver path preserved via ALLOW_LEGACY_OVERLAP_EDIT=true for exceptional migrations with documented rationale

Fixes #578