### PR TITLE
fix(ci): remediate mutable action refs + phase-7d shellcheck opts (#580)

### DIFF
--- a/.github/workflows/TEMPLATE-security-scans.yml
+++ b/.github/workflows/TEMPLATE-security-scans.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       
       - name: TruffleHog scan for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6  # v3.94.3
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
       
       - name: Gitleaks scan
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@e6dab246340401bf53eec993b8f05aebe80ac636  # v2.3.4
         with:
           source: ${{ github.server_url }}/${{ github.repository }}
           verbose: true

--- a/.github/workflows/phase-7d-health-validation.yml
+++ b/.github/workflows/phase-7d-health-validation.yml
@@ -28,7 +28,8 @@ jobs:
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: 'scripts/health'
-          shellcheck_options: '-e SC1091 -e SC2034 -e SC2001'
+        env:
+          SHELLCHECK_OPTS: '-e SC1091 -e SC2034 -e SC2001'
 
       - name: Lint Workflow Files
         run: |

--- a/.github/workflows/qa-coverage-gates.yml
+++ b/.github/workflows/qa-coverage-gates.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@5d5d22fc38ceea83b5bc9c7ff5a5109b73852e9f  # v4.3.1
         with:
           name: coverage-report-${{ github.run_id }}
           path: .coverage-history/


### PR DESCRIPTION
## Summary
Issue #580 remediation slice 4: remove mutable action refs flagged by workflow lint and make Phase 7d health shellcheck suppressions effective.

## Changes
- `.github/workflows/qa-coverage-gates.yml`
  - pinned `actions/upload-artifact` to immutable SHA
- `.github/workflows/TEMPLATE-security-scans.yml`
  - pinned `trufflesecurity/trufflehog` to immutable SHA
  - pinned `gitleaks/gitleaks-action` to immutable SHA
- `.github/workflows/phase-7d-health-validation.yml`
  - switched from ineffective input key to documented env-based options:
    - `SHELLCHECK_OPTS: -e SC1091 -e SC2034 -e SC2001`

## Why
Recent baseline failures include:
- `Detect deprecated/unpinned action versions`
- `Phase 7d-003: Health Validation` shellcheck warnings still failing despite intended suppressions

This PR directly targets those failures with minimal workflow-only changes.

## Scope
Focused remediation for #580; does not attempt to solve broader config-drift baseline debt in this slice.

Refs #580