### PR TITLE
fix(ci): resolve Security Scans startup failure (partial #580)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,6 @@ jobs:
     uses: ./.github/workflows/TEMPLATE-validate-iac.yml
     with:
       check_checkov: true
-      check_tfsec: true
       check_terraform: false
       check_docker_compose: false
 


### PR DESCRIPTION
## Summary Resolve Security Scans startup_failure by removing an unsupported input passed to reusable TEMPLATE-validate-iac workflow.  ## Change - .github/workflows/security.yml   - removed check_tfsec from iac-security.with (input not defined in TEMPLATE-validate-iac.yml)  ## Why GitHub Actions reusable workflow call fails at startup when unknown inputs are provided.  Partial for #580