### PR TITLE
fix(ci): correct Checkov severity input for reusable IaC scans (partial #580)

### DIFF
--- a/.github/workflows/TEMPLATE-validate-iac.yml
+++ b/.github/workflows/TEMPLATE-validate-iac.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: bridgecrewio/checkov-action@de2bfaecd21d58ef232e0d2a3391c33c32c460d7  # v12.3096.0
         with:
           directory: .
-          framework: docker,kubernetes,terraform
+          framework: dockerfile,kubernetes,terraform
           quiet: false
           soft_fail: false
           # Fail on HIGH + CRITICAL only; skip LOW/MEDIUM.

--- a/.github/workflows/TEMPLATE-validate-iac.yml
+++ b/.github/workflows/TEMPLATE-validate-iac.yml
@@ -90,8 +90,8 @@ jobs:
           framework: docker,kubernetes,terraform
           quiet: false
           soft_fail: false
-          # Fail on HIGH + CRITICAL only; skip LOW/MEDIUM
-          check: "-c high,critical"
+          # Fail on HIGH + CRITICAL only; skip LOW/MEDIUM.
+          check: "HIGH,CRITICAL"
         continue-on-error: false
 
       - name: Summary


### PR DESCRIPTION
## Summary
Next #580 remediation slice to fix Checkov execution failure in Security Scans.

## Root Cause
`bridgecrewio/checkov-action` was receiving `check: "-c high,critical"`, which causes runtime error:
`checkov: error: argument -c/--check: expected one argument`.

## Change
- `.github/workflows/TEMPLATE-validate-iac.yml`
  - Updated Checkov input to severity list format expected by the action:
    - from: `check: "-c high,critical"`
    - to: `check: "HIGH,CRITICAL"`

## Expected Result
Security Scans / Checkov path executes with proper severity filtering instead of failing at argument parsing.

Partial for #580