### PR TITLE
fix(ci): resolve Checkov framework conflict in reusable IaC scan template (partial #580)

### DIFF
--- a/.github/workflows/TEMPLATE-validate-iac.yml
+++ b/.github/workflows/TEMPLATE-validate-iac.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: bridgecrewio/checkov-action@de2bfaecd21d58ef232e0d2a3391c33c32c460d7  # v12.3096.0
         with:
           directory: .
-          framework: dockerfile,kubernetes,terraform
+          framework: kubernetes,terraform
           quiet: false
           soft_fail: false
           # Fail on HIGH + CRITICAL only; skip LOW/MEDIUM.


### PR DESCRIPTION
## Summary
Follow-up #580 remediation for Checkov runtime conflict after earlier argument fixes.

## Root Cause
Checkov reported:
Frameworks listed for both --framework and --skip-framework: dockerfile.

## Change
- .github/workflows/TEMPLATE-validate-iac.yml
  - Adjusted Checkov framework list to avoid overlap with its internal/default skip-framework handling:
    - from: dockerfile,kubernetes,terraform
    - to: kubernetes,terraform

## Expected Result
Security Scans Checkov job executes without framework-conflict startup failure.

Partial for #580