### PR TITLE
perf(ide): add code-server performance settings seed + rollout evidence (#592)

### DIFF
--- a/code-server-config.yaml
+++ b/code-server-config.yaml
@@ -17,7 +17,7 @@ proxy-domain:
   - 127.0.0.1
 
 # Logging for audit trail
-logging: debug
+logging: info
 
 # Extensions marketplace
 # NOTE: Disabled marketplace validation since Copilot Chat is pre-installed via VSIX

--- a/config/code-server/settings.json
+++ b/config/code-server/settings.json
@@ -1,0 +1,35 @@
+{
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/node_modules/**": true,
+    "**/dist/**": true,
+    "**/build/**": true,
+    "**/target/**": true,
+    "**/coverage/**": true,
+    "**/.next/**": true,
+    "**/.turbo/**": true,
+    "**/.cache/**": true
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/dist": true,
+    "**/build": true,
+    "**/target": true,
+    "**/coverage": true,
+    "**/.next": true,
+    "**/.turbo": true,
+    "**/.cache": true
+  },
+  "files.exclude": {
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true
+  },
+  "search.followSymlinks": false,
+  "search.useParentIgnoreFiles": true,
+  "typescript.tsserver.maxTsServerMemory": 3072,
+  "editor.minimap.enabled": false,
+  "editor.inlineSuggest.enabled": true,
+  "extensions.autoCheckUpdates": false,
+  "extensions.autoUpdate": false
+}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -356,8 +356,9 @@ services:
     environment:
       PASSWORD: ${CODE_SERVER_PASSWORD}
       SUDO_PASSWORD: ${CODE_SERVER_PASSWORD}
-      NODE_OPTIONS: "--enable-source-maps --max-old-space-size=4000"
+      NODE_OPTIONS: "--max-old-space-size=6144"
       OLLAMA_ENDPOINT: "http://ollama:11434"
+      OLLAMA_DEFAULT_MODEL: "codellama:7b"
       
       # Observability
       OTEL_ENABLED: "true"
@@ -378,11 +379,11 @@ services:
     deploy:
       resources:
         limits:
+          cpus: '4'
+          memory: 8G
+        reservations:
           cpus: '2'
           memory: 4G
-        reservations:
-          cpus: '1'
-          memory: 2G
     logging:
       driver: json-file
       options:
@@ -431,6 +432,7 @@ services:
       OLLAMA_HOST: "0.0.0.0:11434"
       OLLAMA_NUM_GPU: 1
       OLLAMA_MAX_LOADED_MODELS: 2
+      OLLAMA_KEEP_ALIVE: "30m"
     healthcheck:
       # use native CLI to avoid external tool dependencies (curl/wget)
       test: ["CMD", "ollama", "list"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,9 @@ services:
       - SERVICE_URL=https://open-vsx.org/vscode/gallery
       - ITEM_URL=https://open-vsx.org/vscode/item
       - CS_DISABLE_FILE_DOWNLOADS=false
-      - NODE_OPTIONS=--enable-source-maps
+      - NODE_OPTIONS=--max-old-space-size=6144
       - OLLAMA_ENDPOINT=http://ollama:11434
-      - OLLAMA_DEFAULT_MODEL=llama2:7b-chat
+      - OLLAMA_DEFAULT_MODEL=codellama:7b
       - NODE_TLS_REJECT_UNAUTHORIZED=0
       # Development tools environment variables
       - PATH=/home/coder/.local/bin:/home/coder/node_modules/.bin:/usr/local/cargo/bin:/usr/local/go/bin:$PATH
@@ -50,6 +50,7 @@ services:
     volumes:
       - code-server-data:/home/coder
       - ./workspace:/home/coder/workspace
+      - ./config/code-server/settings.json:/etc/code-server/settings.json:ro
       # Mount Docker socket for container development inside IDE
       - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
@@ -61,11 +62,11 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4g
-          cpus: "2.0"
+          memory: 8g
+          cpus: "4.0"
         reservations:
-          memory: 512m
-          cpus: "0.25"
+          memory: 1g
+          cpus: "1.0"
     logging:
       driver: json-file
       options:
@@ -87,7 +88,7 @@ services:
       - "11434"
     environment:
       - OLLAMA_HOST=0.0.0.0:11434
-      - OLLAMA_KEEP_ALIVE=5m
+      - OLLAMA_KEEP_ALIVE=30m
       - OLLAMA_NUM_THREAD=${OLLAMA_NUM_THREAD:-8}
       # ✅ GPU: Set OLLAMA_NUM_GPU to enable GPU acceleration (0=CPU-only by default)
       # To enable GPU:


### PR DESCRIPTION
## Summary
Implements approved lightning-speed optimization rollout items and execution evidence tracking.

## What was implemented
- Added canonical code-server settings seed: `config/code-server/settings.json`
- Includes performance-focused defaults:
  - watcher exclusions for heavy/generated trees
  - search exclusions for heavy/generated trees
  - tsserver memory cap and low-overhead editor defaults

## Execution completed (on 192.168.168.31)
- Deployed updated compose/config artifacts
- Restarted `code-server` and `ollama`
- Verified both containers healthy post-rollout
- Verified runtime values:
  - `NODE_OPTIONS=--max-old-space-size=6144`
  - `OLLAMA_DEFAULT_MODEL=codellama:7b`
  - `OLLAMA_KEEP_ALIVE=30m`
- Verified settings mount present at `/etc/code-server/settings.json`
- Captured smoke latency sample: `ollama list` ~ `0.07s`

## Tracking
Fixes #594
Refs #592
Refs #593
Refs #595
Refs #596