### PR TITLE
fix(portal): route kushnir.cloud to oauth2-proxy-portal (#623)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -33,7 +33,7 @@ ide.kushnir.cloud, ide.kushnir.cloud:443 {
 }
 
 kushnir.cloud {
-    # Root SSO landing is always available and fronted by oauth2-proxy.
+    # Root portal is fronted by oauth2-proxy-portal (admin portal with Appsmith).
 
     encode gzip
 
@@ -52,10 +52,10 @@ kushnir.cloud {
     @logout path /logout /signout
     redir @logout /oauth2/sign_out?rd=https://kushnir.cloud/ 302
 
-    # oauth2-proxy control plane endpoints
+    # oauth2-proxy-portal control plane endpoints
     @oauth2 path /oauth2 /oauth2/*
     handle @oauth2 {
-        reverse_proxy oauth2-proxy:4180 {
+        reverse_proxy oauth2-proxy-portal:4181 {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
         }
@@ -64,8 +64,8 @@ kushnir.cloud {
     # Convenience deep link to IDE app.
     redir /ide https://ide.kushnir.cloud/ 302
 
-    # Root remains SSO protected and reachable even without optional portal profile.
-    reverse_proxy oauth2-proxy:4180 {
+    # Root is SSO protected via oauth2-proxy-portal (Appsmith admin backend).
+    reverse_proxy oauth2-proxy-portal:4181 {
         header_up Host {host}
         header_up X-Real-IP {remote_host}
     }


### PR DESCRIPTION
## Problem
Accessing https://kushnir.cloud returns HTTP 403 Forbidden. The admin portal (Appsmith) is running but unreachable because Caddy's routing configuration sends kushnir.cloud traffic to oauth2-proxy:4180 (IDE auth proxy) instead of oauth2-proxy-portal:4181 (portal auth proxy).

## Root Cause
- oauth2-proxy:4180 proxies IDE traffic (code-server backend)
- oauth2-proxy-portal:4181 proxies portal traffic (Appsmith backend)
- Caddyfile kushnir.cloud block incorrectly used port 4180
- Result: 403 responses because oauth2-proxy:4180 cannot proxy to Appsmith

## Solution
Route kushnir.cloud to oauth2-proxy-portal:4181 instead of oauth2-proxy:4180.

## Changes
- Updated kushnir.cloud block to reverse_proxy oauth2-proxy-portal:4181
- Updated oauth2 endpoint matcher to use oauth2-proxy-portal:4181
- Preserved all security headers, health checks, and SSO functionality

## Verification
After merge and deployment:
\\\ash
curl -v https://kushnir.cloud/
# Should return 303 redirect to /oauth2/start (not 403)
\\\

## Impact
- **Severity**: 🔴 P0 - Critical (blocks admin portal and credential management)
- **Scope**: Routing configuration only (no code changes)
- **Risk**: Minimal (only affects kushnir.cloud routing, not IDE or other services)
- **Rollback**: Trivial (revert 5 lines in Caddyfile)

## Blocks
- #622: Workspace credential provisioning
- #580: Admin portal controls

Fixes #623