### PR TITLE
fix(oauth): enforce surface-specific redirect callbacks and add redeploy helper

### DIFF
--- a/.env.schema.json
+++ b/.env.schema.json
@@ -87,9 +87,23 @@
         "OAUTH2_REDIRECT_URL": {
           "type": "string",
           "format": "url",
-          "required": true,
+          "required": false,
           "example": "https://ide.kushnir.cloud/oauth2/callback",
-          "description": "OAuth2 callback URL (must match Google Console)"
+          "description": "Legacy shared OAuth2 callback URL; prefer surface-specific redirect URLs"
+        },
+        "OAUTH2_PROXY_IDE_REDIRECT_URL": {
+          "type": "string",
+          "format": "url",
+          "required": false,
+          "example": "https://ide.kushnir.cloud/oauth2/callback",
+          "description": "IDE OAuth2 callback URL (must match Google Console)"
+        },
+        "OAUTH2_PROXY_PORTAL_REDIRECT_URL": {
+          "type": "string",
+          "format": "url",
+          "required": false,
+          "example": "https://kushnir.cloud/oauth2/callback",
+          "description": "Portal OAuth2 callback URL (must match Google Console)"
         },
         "OAUTH2_PROXY_COOKIE_SECRET": {
           "type": "string",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
       OAUTH2_PROXY_COOKIE_SECRET: "${OAUTH2_PROXY_COOKIE_SECRET}"
       OAUTH2_PROXY_PROVIDER: "google"
       OAUTH2_PROXY_OIDC_ISSUER_URL: "https://accounts.google.com"
-      OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_REDIRECT_URL:-https://ide.kushnir.cloud/oauth2/callback}"
+      OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_PROXY_IDE_REDIRECT_URL:-${OAUTH2_REDIRECT_URL:-https://ide.kushnir.cloud/oauth2/callback}}"
       OAUTH2_PROXY_UPSTREAMS: "http://code-server:8080/"
       # Allow any Google domain to attempt auth; authenticated-emails-file is the real gate.
       # This prevents org_internal 403 errors for accounts outside bioenergystrategies.com (e.g. gmail.com).
@@ -239,7 +239,7 @@ services:
       OAUTH2_PROXY_COOKIE_SECRET: "${OAUTH2_PROXY_COOKIE_SECRET}"
       OAUTH2_PROXY_PROVIDER: "google"
       OAUTH2_PROXY_OIDC_ISSUER_URL: "https://accounts.google.com"
-      OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_REDIRECT_URL:-https://ide.kushnir.cloud/oauth2/callback}"
+      OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_PROXY_PORTAL_REDIRECT_URL:-https://kushnir.cloud/oauth2/callback}"
       OAUTH2_PROXY_UPSTREAMS: "http://appsmith:80/"
       # Allow any Google domain to complete OAuth; authenticated-emails-file remains the real gate.
       # This prevents Google from returning org_internal 403 before our explicit allowlist is checked.

--- a/docs/governance/GLOBAL-DEDUP-GOVERNANCE.md
+++ b/docs/governance/GLOBAL-DEDUP-GOVERNANCE.md
@@ -40,7 +40,7 @@ Waiver control:
 1. No new top-level compose variants beyond docker-compose.yml.
 2. No new Caddyfile variants beyond Caddyfile.
 3. Keep main.tf and terraform/main.tf synchronized whenever either mirror is changed.
-4. OAuth callback settings must be centralized using OAUTH2_REDIRECT_URL in docker-compose.yml.
+4. OAuth callback settings must remain surface-specific in docker-compose.yml: IDE uses OAUTH2_PROXY_IDE_REDIRECT_URL and portal uses OAUTH2_PROXY_PORTAL_REDIRECT_URL.
 5. New documentation files under docs/ must not create normalized filename collisions with existing docs.
 
 ## Enforcement

--- a/scripts/MANIFEST.toml
+++ b/scripts/MANIFEST.toml
@@ -141,6 +141,12 @@ status   = "active"
 purpose  = "TODO: add purpose"
 
 [[script]]
+file     = "deploy/redeploy-portal-oauth-routing.sh"
+category = "deployment"
+status   = "active"
+purpose  = "Idempotently upload the canonical compose file and recreate the portal OAuth routing services on the primary host"
+
+[[script]]
 file     = "deployment-validation-31.sh"
 category = "uncategorized"
 status   = "active"

--- a/scripts/ci/enforce-global-dedup.sh
+++ b/scripts/ci/enforce-global-dedup.sh
@@ -164,15 +164,16 @@ fi
 # 4) Enforce single callback variable pattern in canonical compose auth blocks.
 if [[ -f "${CANONICAL_COMPOSE}" ]]; then
   callback_count="$(grep -c 'OAUTH2_PROXY_REDIRECT_URL:' "${CANONICAL_COMPOSE}" || true)"
-  callback_var_count="$(grep -c 'OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_REDIRECT_URL:-https://ide.kushnir.cloud/oauth2/callback}"' "${CANONICAL_COMPOSE}" || true)"
+  ide_callback_count="$(grep -cF 'OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_PROXY_IDE_REDIRECT_URL:-${OAUTH2_REDIRECT_URL:-https://ide.kushnir.cloud/oauth2/callback}}"' "${CANONICAL_COMPOSE}" || true)"
+  portal_callback_count="$(grep -cF 'OAUTH2_PROXY_REDIRECT_URL: "${OAUTH2_PROXY_PORTAL_REDIRECT_URL:-https://kushnir.cloud/oauth2/callback}"' "${CANONICAL_COMPOSE}" || true)"
 
   if [[ "${callback_count}" -lt 2 ]]; then
     log_error "Expected at least 2 OAUTH2_PROXY_REDIRECT_URL entries in ${CANONICAL_COMPOSE}, found ${callback_count}"
     failures=$((failures + 1))
   fi
 
-  if [[ "${callback_var_count}" -lt 2 ]]; then
-    log_error "Auth callback in ${CANONICAL_COMPOSE} is not centralized via OAUTH2_REDIRECT_URL in both proxy blocks"
+  if [[ "${ide_callback_count}" -lt 1 || "${portal_callback_count}" -lt 1 ]]; then
+    log_error "Auth callbacks in ${CANONICAL_COMPOSE} must use distinct IDE and portal redirect variables"
     failures=$((failures + 1))
   fi
 fi

--- a/scripts/deploy/redeploy-portal-oauth-routing.sh
+++ b/scripts/deploy/redeploy-portal-oauth-routing.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# @file        scripts/deploy/redeploy-portal-oauth-routing.sh
+# @module      deployment/oauth
+# @description idempotently redeploy portal oauth routing on the primary host
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../_common/init.sh"
+
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCRIPT_NAME="$(basename "$0")"
+
+readonly LOCAL_COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yml"
+readonly REMOTE_COMPOSE_FILE="${DOCKER_COMPOSE_FILE}"
+readonly PORTAL_CALLBACK_URL="${OAUTH2_PROXY_PORTAL_REDIRECT_URL:-https://kushnir.cloud/oauth2/callback}"
+readonly IDE_CALLBACK_URL="${OAUTH2_PROXY_IDE_REDIRECT_URL:-${OAUTH2_REDIRECT_URL:-https://ide.kushnir.cloud/oauth2/callback}}"
+readonly PORTAL_SERVICES=(oauth2-proxy-portal caddy appsmith)
+
+DRY_RUN=false
+
+usage() {
+    cat <<EOF
+Usage: ${SCRIPT_NAME} [--dry-run]
+
+Uploads the canonical docker-compose.yml to the primary host and
+recreates only the portal routing services with COMPOSE_PROFILES=portal.
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                log_fatal "Unknown option: $1"
+                ;;
+        esac
+    done
+}
+
+run_remote() {
+    local command="$1"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        log_info "[dry-run] ssh ${DEPLOY_USER}@${DEPLOY_HOST} ${command}"
+        return 0
+    fi
+
+    ssh_exec "$command"
+}
+
+upload_compose() {
+    if [[ "$DRY_RUN" == true ]]; then
+        log_info "[dry-run] scp ${LOCAL_COMPOSE_FILE} ${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_COMPOSE_FILE}"
+        return 0
+    fi
+
+    ssh_upload "${LOCAL_COMPOSE_FILE}" "${REMOTE_COMPOSE_FILE}"
+}
+
+verify_local_compose() {
+    require_file "${LOCAL_COMPOSE_FILE}"
+
+    if ! grep -qF "${PORTAL_CALLBACK_URL}" "${LOCAL_COMPOSE_FILE}"; then
+        log_fatal "Local compose file does not contain the portal callback URL: ${PORTAL_CALLBACK_URL}"
+    fi
+
+    if ! grep -qF "${IDE_CALLBACK_URL}" "${LOCAL_COMPOSE_FILE}"; then
+        log_fatal "Local compose file does not contain the IDE callback URL: ${IDE_CALLBACK_URL}"
+    fi
+
+    log_info "Verified local compose file contains distinct IDE and portal callback URLs"
+}
+
+verify_remote_compose() {
+    run_remote "grep -qF '${PORTAL_CALLBACK_URL}' '${REMOTE_COMPOSE_FILE}'"
+    run_remote "grep -qF '${IDE_CALLBACK_URL}' '${REMOTE_COMPOSE_FILE}'"
+    log_info "Verified remote compose file contains the expected callback URLs"
+}
+
+redeploy_services() {
+    run_remote "cd '${DEPLOY_DIR}' && COMPOSE_PROFILES=portal docker compose up -d --remove-orphans ${PORTAL_SERVICES[*]}"
+    log_info "Requested idempotent portal service redeploy"
+}
+
+wait_for_remote_service() {
+    local service_name="$1"
+    local attempt
+
+    for attempt in $(seq 1 12); do
+        if run_remote "docker inspect --format '{{.State.Running}}' '${service_name}' 2>/dev/null | grep -q true"; then
+            log_info "Service is running: ${service_name}"
+            return 0
+        fi
+        if [[ "$DRY_RUN" == false ]]; then
+            sleep 5
+        fi
+    done
+
+    log_fatal "Timed out waiting for service: ${service_name}"
+}
+
+verify_oauth_routes() {
+    run_remote "curl -ksS -o /dev/null -D - 'https://kushnir.cloud/oauth2/start?rd=/' | grep -qi 'location: .*redirect_uri=https%3A%2F%2Fkushnir.cloud%2Foauth2%2Fcallback'"
+    run_remote "curl -ksS -o /dev/null -D - 'https://ide.kushnir.cloud/oauth2/start?rd=/' | grep -qi 'location: .*redirect_uri=https%3A%2F%2Fide.kushnir.cloud%2Foauth2%2Fcallback'"
+    log_info "Verified apex and IDE OAuth start endpoints point to distinct callbacks"
+}
+
+main() {
+    parse_args "$@"
+
+    require_commands ssh scp grep curl
+    verify_local_compose
+
+    if [[ "$DRY_RUN" == false ]]; then
+        assert_deploy_access
+    fi
+
+    log_info "Uploading canonical compose file to ${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_COMPOSE_FILE}"
+    upload_compose
+    verify_remote_compose
+
+    log_info "Redeploying portal services: ${PORTAL_SERVICES[*]}"
+    redeploy_services
+
+    wait_for_remote_service "oauth2-proxy-portal"
+    wait_for_remote_service "caddy"
+
+    verify_oauth_routes
+    log_info "${SCRIPT_NAME} completed successfully"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- enforce distinct OAuth redirect URLs per surface in docker-compose:
  - IDE: OAUTH2_PROXY_IDE_REDIRECT_URL (with legacy fallback)
  - Portal: OAUTH2_PROXY_PORTAL_REDIRECT_URL
- update env schema for new redirect variables
- update dedup governance rule and CI dedup enforcement for surface-specific callbacks
- add idempotent deploy helper script: scripts/deploy/redeploy-portal-oauth-routing.sh
- register deploy script in scripts/MANIFEST.toml

## Validation
- bash scripts/ci/enforce-global-dedup.sh
- bash scripts/deploy/redeploy-portal-oauth-routing.sh --dry-run
- jq . .env.schema.json

## Links
- Fixes #643