### PR TITLE
fix(oauth): normalize WIF provider for GSM bootstrap

### DIFF
--- a/.github/workflows/portal-oauth-redeploy.yml
+++ b/.github/workflows/portal-oauth-redeploy.yml
@@ -38,20 +38,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-<<<<<<< Updated upstream
-          provider="$GCP_WIF_PROVIDER_RAW"
-          provider="${provider#"${provider%%[![:space:]]*}"}"
-          provider="${provider%"${provider##*[![:space:]]}"}"
-          provider="${provider#http://iam.googleapis.com/}"
-=======
+          if [[ -z "${GCP_PROJECT_ID:-}" ]]; then
+            echo "GCP_PROJECT is required to resolve the canonical WIF provider" >&2
+            exit 1
+          fi
+
           default_provider="projects/${GCP_PROJECT_ID}/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           provider="${GCP_WIF_PROVIDER_RAW:-$default_provider}"
           provider="${provider#"${provider%%[![:space:]]*}"}"
           provider="${provider%"${provider##*[![:space:]]}"}"
           provider="${provider#//iam.googleapis.com/}"
->>>>>>> Stashed changes
           provider="${provider#https://iam.googleapis.com/}"
-          provider="${provider#//iam.googleapis.com/}"
           provider="${provider#iam.googleapis.com/}"
           if [[ "$provider" != projects/*/locations/global/workloadIdentityPools/*/providers/* ]]; then
             echo "GCP_WIF_PROVIDER is not a canonical provider resource; using ${default_provider}" >&2

--- a/.github/workflows/portal-oauth-redeploy.yml
+++ b/.github/workflows/portal-oauth-redeploy.yml
@@ -37,11 +37,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          provider="${GCP_WIF_PROVIDER_RAW#"${GCP_WIF_PROVIDER_RAW%%[![:space:]]*}"}"
+          provider="$GCP_WIF_PROVIDER_RAW"
+          provider="${provider#"${provider%%[![:space:]]*}"}"
           provider="${provider%"${provider##*[![:space:]]}"}"
           provider="${provider#http://iam.googleapis.com/}"
-          provider="${GCP_WIF_PROVIDER_RAW#//iam.googleapis.com/}"
           provider="${provider#https://iam.googleapis.com/}"
+          provider="${provider#//iam.googleapis.com/}"
           provider="${provider#iam.googleapis.com/}"
           if [[ -z "$provider" ]]; then
             echo "GCP_WIF_PROVIDER is empty after normalization" >&2

--- a/.github/workflows/portal-oauth-redeploy.yml
+++ b/.github/workflows/portal-oauth-redeploy.yml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: portal-oauth-redeploy-production
+  group: portal-oauth-redeploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/portal-oauth-redeploy.yml
+++ b/.github/workflows/portal-oauth-redeploy.yml
@@ -30,31 +30,44 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Normalize WIF provider value
+      - name: Resolve canonical WIF provider
         if: ${{ !inputs.dry_run && !hashFiles('.env') }}
         env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT }}
           GCP_WIF_PROVIDER_RAW: ${{ secrets.GCP_WIF_PROVIDER }}
         shell: bash
         run: |
           set -euo pipefail
+<<<<<<< Updated upstream
           provider="$GCP_WIF_PROVIDER_RAW"
           provider="${provider#"${provider%%[![:space:]]*}"}"
           provider="${provider%"${provider##*[![:space:]]}"}"
           provider="${provider#http://iam.googleapis.com/}"
+=======
+          default_provider="projects/${GCP_PROJECT_ID}/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+          provider="${GCP_WIF_PROVIDER_RAW:-$default_provider}"
+          provider="${provider#"${provider%%[![:space:]]*}"}"
+          provider="${provider%"${provider##*[![:space:]]}"}"
+          provider="${provider#//iam.googleapis.com/}"
+>>>>>>> Stashed changes
           provider="${provider#https://iam.googleapis.com/}"
           provider="${provider#//iam.googleapis.com/}"
           provider="${provider#iam.googleapis.com/}"
+          if [[ "$provider" != projects/*/locations/global/workloadIdentityPools/*/providers/* ]]; then
+            echo "GCP_WIF_PROVIDER is not a canonical provider resource; using ${default_provider}" >&2
+            provider="$default_provider"
+          fi
           if [[ -z "$provider" ]]; then
-            echo "GCP_WIF_PROVIDER is empty after normalization" >&2
+            echo "GCP_WIF_PROVIDER resolved to an empty provider" >&2
             exit 1
           fi
-          echo "GCP_WIF_PROVIDER_NORMALIZED=$provider" >> "$GITHUB_ENV"
+          echo "GCP_WIF_PROVIDER_RESOLVED=$provider" >> "$GITHUB_ENV"
 
       - name: Authenticate to GCP via Workload Identity
         if: ${{ !inputs.dry_run && !hashFiles('.env') }}
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER_NORMALIZED }}
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER_RESOLVED }}
           service_account: ${{ secrets.GCP_SA }}
 
       - name: Setup gcloud CLI

--- a/docs/status/AUTONOMOUS-OPEN-ISSUE-STATUS-2026-04-18.md
+++ b/docs/status/AUTONOMOUS-OPEN-ISSUE-STATUS-2026-04-18.md
@@ -42,16 +42,18 @@ Canonical machine-readable companion:
 ## Open Issues Without Landed Implementation Yet
 
 - `#692` Provide reachable execution path for portal OAuth redeploy workflow
+- `#695` Add non-interactive GSM auth path for self-hosted portal redeploy workflow
 - `#686` fix(oauth): enforce surface-specific redirect callbacks and add redeploy helper
 - `#684` feat(monorepo): bootstrap pnpm workspace and lockfile governance
 - `#649` feat(policy): Implement VS Code Enterprise Policy Pack v1.0 (#618)
 
 ## Recommended Execution Order
 
-1. `#692` provision a reachable execution path and re-run the hardened portal workflow.
-2. `#686` keep the OAuth helper lane aligned with the portal redeploy path and review the open PR.
-3. `#684` keep the monorepo/pnpm governance lane moving independently of the release blocker.
-4. `#649` keep the policy-pack governance lane moving independently of the release blocker.
+1. `#695` provision non-interactive GSM auth for self-hosted portal redeploy workflow execution.
+2. `#692` re-run the hardened portal workflow with secret bootstrap available and complete live redirect verification.
+3. `#686` keep the OAuth helper lane aligned with the portal redeploy path and review the open PR.
+4. `#684` keep the monorepo/pnpm governance lane moving independently of the release blocker.
+5. `#649` keep the policy-pack governance lane moving independently of the release blocker.
 
 ## Operational Notes
 
@@ -59,7 +61,8 @@ Canonical machine-readable companion:
 - `#690` is resolved: the deploy SSH secret is now provisioned in GitHub Actions.
 - Local portal redeploy dry-run now passes with `bash scripts/deploy/redeploy-portal-oauth-routing.sh --dry-run --local`, and the temporary self-hosted runner validated both the portal dry-run and the VPN gate.
 - `#691` is closed: the legacy docs-root bridge files were collapsed to compatibility stubs and the canonical folder indexes remain in place.
-- The latest published portal OAuth run still fails in the Redeploy portal services step because the published workflow invokes the helper in SSH mode and the host rejects the key.
-- The published branch fix `fix/692-local-execution-path` reached the redeploy step but failed because the self-hosted runner lacked `docker`; the next blocker is a Docker-capable runner or host-side execution path.
+- PR #693 is merged and the published portal workflow now uses the self-hosted local execution path.
+- Docker is now available on the temporary self-hosted runner path, and the deploy job reaches workflow env bootstrap.
+- The active blocker is secret material on ephemeral runners: runs `24609720382` and `24609751800` fail because GSM fetch is unauthenticated and production environment OAuth secrets are not configured.
 - `#686`, `#684`, and `#649` are open PR-backed lanes with existing repo artifacts; they are parallel review tracks, not the current release blocker.
 - Keep issue comments current when additional AC evidence lands so GitHub remains usable without local context.

--- a/docs/triage/AUTONOMOUS-EXECUTION-PLAYBOOK-2026-04-18.md
+++ b/docs/triage/AUTONOMOUS-EXECUTION-PLAYBOOK-2026-04-18.md
@@ -9,14 +9,16 @@ This playbook is the canonical handoff for parallel agents working from branch `
 - Branch feature: #671
 - CI stabilization blocker: #687
 - Production OAuth redeploy blocker: #692
+- Secret bootstrap blocker: #695
 
 ## Closed Duplicate
 - #689 (duplicate of #687)
 
 ## Dependency Order
 1. Resolve #687 first (branch CI determinism).
-2. Resolve #692 second (production callback redeploy execution path + runtime verification).
-3. Resume completion/closure flow for #671 once #687 and #692 are closed.
+2. Resolve #695 second (non-interactive GSM auth and ephemeral secret bootstrap on self-hosted runners).
+3. Resolve #692 third (production callback redeploy execution path + runtime verification).
+4. Resume completion/closure flow for #671 once #687, #695, and #692 are closed.
 
 ## Issue #687 Execution Checklist
 - Reproduce failing workflows listed in issue body.
@@ -47,6 +49,7 @@ This playbook is the canonical handoff for parallel agents working from branch `
 - Temporary self-hosted runner evidence: portal-oauth-redeploy.yml run `24608948773` succeeded; vpn-e2e-gate.yml run `24608949154` succeeded.
 - Live apex redirect still points to IDE callback until #692 is executed.
 - Docs consolidation tracker #691 is closed; the legacy docs-root files are compatibility stubs and the canonical indexes are in place.
-- Latest published portal OAuth run `24609258258` failed during SSH authentication in the Redeploy portal services step.
-- Branch `fix/692-local-execution-path` run `24609414318` reached the deploy step but failed because the runner lacked `docker`.
+- PR #693 is merged on `main`; the portal workflow now runs the local execution path on self-hosted runners.
+- Docker is available on the temporary self-hosted runner path.
+- Latest portal runs `24609720382` and `24609751800` fail in env bootstrap because the runner lacks non-interactive GSM auth and production environment OAuth secrets are not configured.
 - Parallel open PR lanes remain for #686, #684, and #649; keep them separate from the production blocker path.


### PR DESCRIPTION
Normalize the GCP WIF provider value before authenticating to GCP so the portal OAuth redeploy workflow can bootstrap GSM secrets non-interactively on self-hosted runners.

Fixes #695
Refs #692