### PR TITLE
fix: replace hardcoded AWS access key with safe test value

### DIFF
--- a/scripts/deploy-terminal-dlp.sh
+++ b/scripts/deploy-terminal-dlp.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# @file        scripts/deploy-terminal-dlp.sh
+# @module      security/data-loss-prevention
+# @description Deploy terminal output DLP for issue #1274
+#
+# Deploys real-time terminal output scanning to prevent credential/PII leakage.
+# Scans for AWS keys, GitHub tokens, passwords, emails, credit cards, and more.
+# Redacts or blocks sensitive data with < 5ms performance impact.
+
+set -euo pipefail
+
+# Source common utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common/init.sh"
+
+log_info "Deploying terminal output DLP (Issue #1274)..."
+
+# Check if terminal-output-optimizer service is running
+if ! docker-compose ps | grep -q "terminal-output-optimizer"; then
+    log_warn "Terminal output optimizer service retired (archived)"
+    log_info "DLP implemented as standalone service"
+    log_info "Starting DLP service..."
+    
+    # Start DLP service (placeholder - would need docker-compose service)
+    log_warn "DLP service not yet added to docker-compose.yml"
+    log_info "Manual integration required into session-broker or code-server"
+else
+    log_info "Terminal output optimizer service is running"
+fi
+
+# Verify DLP configuration
+log_info "Verifying DLP configuration..."
+
+# Check if DLP is enabled in the service
+if ! grep -q "enable_dlp.*True" services/terminal-output-optimizer.py 2>/dev/null; then
+    log_info "DLP is enabled by default in terminal-output-optimizer.py"
+else
+    log_info "DLP configuration found"
+fi
+
+# Test DLP functionality
+log_info "Testing DLP functionality..."
+
+# Create a simple test
+python3 -c "
+from services.terminal_output_optimizer import TerminalOutputDLP
+dlp = TerminalOutputDLP()
+test_cases = [
+    'echo hello world',  # Should pass
+    'export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE',  # Should redact (fake test key)
+    'git config --global user.email user@example.com',  # Should redact
+]
+for case in test_cases:
+    result = dlp.scan(case)
+    print(f'Input: {case}')
+    print(f'Action: {result[\"action\"]}')
+    print(f'Output: {result[\"sanitized\"]}')
+    print('---')
+"
+
+log_info "DLP test completed"
+
+# Restart services to pick up any configuration changes
+log_info "Restarting terminal output optimizer..."
+docker-compose restart terminal-output-optimizer 2>/dev/null || log_warn "Terminal optimizer service not in docker-compose"
+
+log_info "Terminal output DLP deployed successfully"
+log_info "Real-time scanning active for:"
+log_info "  - Private keys (RSA, SSH, EC, PGP)"
+log_info "  - API tokens (GitHub PAT, Slack, Bearer)"
+log_info "  - Credentials (AWS keys, passwords)"
+log_info "  - PII (emails, phone numbers, credit cards)"
+log_info "Mode: redact (sensitive data hidden, context preserved)"
+log_info "< 5ms performance impact per scan"


### PR DESCRIPTION
## Security Fix: Remove Hardcoded AWS Access Key from Test Code

**Issue**: #1330 - [SECURITY][trivy] aws-access-key-id in scripts/deploy-terminal-dlp.sh:50

### Problem
The trivy security scanner detected a hardcoded AWS access key ID in the DLP test code:
```
export AWS_ACCESS_KEY_ID=AKIA1234567890123456
```

### Solution
Replaced the potentially sensitive test value with the standard AWS documentation example key:
```
export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
```

This is the official AWS example key used in documentation and is safe for testing purposes.

### Changes
- `scripts/deploy-terminal-dlp.sh`: Updated test case to use safe example key

### Verification
- Security scan should no longer flag this as a vulnerability
- DLP functionality remains intact
- Test case still validates AWS key redaction

Fixes #1330