### PR TITLE
feat(collaboration): add rich presence backend service

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -31,6 +31,7 @@ export { initializeActivityFeedRoutes, ActivityFeedService } from './routes/acti
 export { initializeGuestSessionRoutes, GuestSessionService } from './routes/guest-sessions';
 export { initializeSharedPromptLibraryRoutes, SharedPromptLibraryService } from './routes/shared-prompt-library';
 export { initializeAIReviewerRouterRoutes, AIReviewerRouterService } from './routes/ai-reviewer-router';
+export { initializeRichPresenceRoutes, RichPresenceService } from './routes/rich-presence';
 export { initializeSessionReplayTimelineRoutes, SessionReplayTimelineService } from './services/session-replay-timeline';
 export { initializeCapacityForecastingRoutes, CapacityForecastingService } from './services/capacity-forecasting';
 export { initializeFunnelAnalyticsRoutes, FunnelAnalyticsService } from './services/funnel-analytics';

--- a/apps/backend/src/routes/rich-presence.ts
+++ b/apps/backend/src/routes/rich-presence.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// @file        apps/backend/src/routes/rich-presence.ts
+// @module      collaboration/rich-presence
+// @description REST API routes for rich presence state
+// @owner       collab-4.1
+// @status      active
+
+import { Request, Response, Router } from 'express';
+import { RichPresenceService } from '../services/rich-presence';
+import { getLogger } from '../lib/logger';
+
+const logger = getLogger('RichPresenceRoutes');
+
+export function initializeRichPresenceRoutes(service: RichPresenceService): Router {
+  const router = Router();
+
+  router.post('/api/presence/users/:userId', async (req: Request, res: Response) => {
+    try {
+      const record = await service.upsertPresence({
+        userId: req.params.userId,
+        teamId: req.body?.teamId,
+        filePath: req.body?.filePath,
+        functionName: req.body?.functionName,
+        task: req.body?.task,
+        customStatus: req.body?.customStatus,
+        sessionId: req.body?.sessionId,
+      });
+
+      res.status(201).json(record);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to upsert presence';
+      logger.error('Failed to upsert presence', { error, body: req.body, params: req.params });
+      res.status(400).json({ error: message });
+    }
+  });
+
+  router.get('/api/presence/users/:userId', async (req: Request, res: Response) => {
+    try {
+      const presence = await service.getPresence(req.params.userId);
+      if (!presence) {
+        return res.status(404).json({ error: 'Presence not found' });
+      }
+
+      res.json(presence);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to get presence';
+      logger.error('Failed to get presence', { error, params: req.params });
+      res.status(400).json({ error: message });
+    }
+  });
+
+  router.get('/api/presence/teams/:teamId', async (req: Request, res: Response) => {
+    try {
+      const records = await service.listTeamPresence(req.params.teamId);
+      res.json({ teamId: req.params.teamId, count: records.length, records });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to list team presence';
+      logger.error('Failed to list team presence', { error, params: req.params });
+      res.status(400).json({ error: message });
+    }
+  });
+
+  router.delete('/api/presence/users/:userId', async (req: Request, res: Response) => {
+    try {
+      await service.clearPresence(req.params.userId);
+      res.json({ success: true });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to clear presence';
+      logger.error('Failed to clear presence', { error, params: req.params });
+      res.status(400).json({ error: message });
+    }
+  });
+
+  return router;
+}
+
+export { RichPresenceService } from '../services/rich-presence';

--- a/apps/backend/src/services/rich-presence/__tests__/rich-presence.test.ts
+++ b/apps/backend/src/services/rich-presence/__tests__/rich-presence.test.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// @file        apps/backend/src/services/rich-presence/__tests__/rich-presence.test.ts
+// @module      collaboration/rich-presence
+// @description Tests for Redis-backed rich presence system behavior
+// @owner       collab-4.1
+// @status      active
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RichPresenceService, RedisLike, RICH_PRESENCE_TTL_SECONDS } from '../index';
+
+vi.mock('../../../lib/logger', () => ({
+  getLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+class InMemoryRedis implements RedisLike {
+  private values = new Map<string, string>();
+  private sets = new Map<string, Set<string>>();
+  private ttl = new Map<string, number>();
+
+  async get(key: string): Promise<string | null> {
+    return this.values.has(key) ? (this.values.get(key) as string) : null;
+  }
+
+  async set(key: string, value: string, mode?: string, duration?: number): Promise<unknown> {
+    this.values.set(key, value);
+    if (mode === 'EX' && duration) {
+      this.ttl.set(key, duration);
+    }
+    return 'OK';
+  }
+
+  async del(key: string): Promise<number> {
+    const existed = this.values.delete(key);
+    return existed ? 1 : 0;
+  }
+
+  async sadd(key: string, ...members: string[]): Promise<number> {
+    const set = this.sets.get(key) || new Set<string>();
+    const before = set.size;
+    for (const member of members) {
+      set.add(member);
+    }
+    this.sets.set(key, set);
+    return set.size - before;
+  }
+
+  async srem(key: string, ...members: string[]): Promise<number> {
+    const set = this.sets.get(key) || new Set<string>();
+    let removed = 0;
+    for (const member of members) {
+      if (set.delete(member)) {
+        removed += 1;
+      }
+    }
+    this.sets.set(key, set);
+    return removed;
+  }
+
+  async smembers(key: string): Promise<string[]> {
+    return Array.from(this.sets.get(key) || []);
+  }
+
+  async expire(key: string, seconds: number): Promise<number> {
+    this.ttl.set(key, seconds);
+    return 1;
+  }
+
+  getTtl(key: string): number | undefined {
+    return this.ttl.get(key);
+  }
+}
+
+describe('RichPresenceService', () => {
+  let redis: InMemoryRedis;
+  let service: RichPresenceService;
+
+  beforeEach(() => {
+    redis = new InMemoryRedis();
+    service = new RichPresenceService(redis);
+  });
+
+  it('upserts and retrieves presence with required fields', async () => {
+    const record = await service.upsertPresence({
+      userId: 'alice',
+      teamId: 'team-1',
+      filePath: 'src/routes/index.ts',
+      functionName: 'initializeRoutes',
+      task: 'wiring routes',
+      customStatus: 'reviewing',
+      sessionId: 'session-a',
+    });
+
+    expect(record.userId).toBe('alice');
+    expect(record.functionName).toBe('initializeRoutes');
+
+    const loaded = await service.getPresence('alice');
+    expect(loaded?.teamId).toBe('team-1');
+    expect(loaded?.task).toBe('wiring routes');
+  });
+
+  it('sets 4-hour TTL for user and team presence keys', async () => {
+    await service.upsertPresence({
+      userId: 'bob',
+      teamId: 'team-2',
+      filePath: 'src/app.ts',
+    });
+
+    expect(redis.getTtl('rich_presence:user:bob')).toBe(RICH_PRESENCE_TTL_SECONDS);
+    expect(redis.getTtl('rich_presence:team:team-2:users')).toBe(RICH_PRESENCE_TTL_SECONDS);
+  });
+
+  it('lists team presence and orders by latest update', async () => {
+    await service.upsertPresence({
+      userId: 'alice',
+      teamId: 'team-1',
+      filePath: 'src/a.ts',
+      task: 'first',
+    });
+
+    await service.upsertPresence({
+      userId: 'charlie',
+      teamId: 'team-1',
+      filePath: 'src/c.ts',
+      task: 'second',
+    });
+
+    const listed = await service.listTeamPresence('team-1');
+    expect(listed).toHaveLength(2);
+    expect(listed.map((entry) => entry.userId).sort()).toEqual(['alice', 'charlie']);
+  });
+
+  it('clears presence and removes user from team set', async () => {
+    await service.upsertPresence({
+      userId: 'dana',
+      teamId: 'team-3',
+      filePath: 'src/d.ts',
+    });
+
+    await service.clearPresence('dana');
+
+    const loaded = await service.getPresence('dana');
+    expect(loaded).toBeNull();
+
+    const teamUsers = await redis.smembers('rich_presence:team:team-3:users');
+    expect(teamUsers).not.toContain('dana');
+  });
+});

--- a/apps/backend/src/services/rich-presence/index.ts
+++ b/apps/backend/src/services/rich-presence/index.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// @file        apps/backend/src/services/rich-presence/index.ts
+// @module      collaboration/rich-presence
+// @description Redis-backed rich presence service with 4h TTL persistence
+// @owner       collab-4.1
+// @status      active
+
+import { EventEmitter } from 'events';
+import Redis from 'ioredis';
+import { getLogger } from '../../lib/logger';
+
+export const RICH_PRESENCE_TTL_SECONDS = 4 * 60 * 60;
+
+export interface RichPresenceUpdateInput {
+  userId: string;
+  teamId: string;
+  filePath: string;
+  functionName?: string;
+  task?: string;
+  customStatus?: string;
+  sessionId?: string;
+}
+
+export interface RichPresenceRecord {
+  userId: string;
+  teamId: string;
+  filePath: string;
+  functionName: string;
+  task: string;
+  customStatus: string;
+  sessionId: string;
+  updatedAt: string;
+}
+
+export interface RedisLike {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, mode?: string, duration?: number): Promise<unknown>;
+  del(key: string): Promise<number>;
+  sadd(key: string, ...members: string[]): Promise<number>;
+  srem(key: string, ...members: string[]): Promise<number>;
+  smembers(key: string): Promise<string[]>;
+  expire(key: string, seconds: number): Promise<number>;
+}
+
+export class RichPresenceService extends EventEmitter {
+  private readonly logger = getLogger('RichPresenceService');
+  private readonly redis: RedisLike;
+
+  constructor(redis?: RedisLike) {
+    super();
+    if (redis) {
+      this.redis = redis;
+      return;
+    }
+
+    const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+    this.redis = new Redis(redisUrl);
+  }
+
+  async upsertPresence(input: RichPresenceUpdateInput): Promise<RichPresenceRecord> {
+    this.require(input.userId, 'userId');
+    this.require(input.teamId, 'teamId');
+    this.require(input.filePath, 'filePath');
+
+    const record: RichPresenceRecord = {
+      userId: input.userId.trim(),
+      teamId: input.teamId.trim(),
+      filePath: input.filePath.trim(),
+      functionName: (input.functionName || '').trim(),
+      task: (input.task || '').trim(),
+      customStatus: (input.customStatus || '').trim(),
+      sessionId: (input.sessionId || '').trim(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const userKey = this.userKey(record.userId);
+    const teamSetKey = this.teamSetKey(record.teamId);
+
+    await this.redis.set(userKey, JSON.stringify(record), 'EX', RICH_PRESENCE_TTL_SECONDS);
+    await this.redis.sadd(teamSetKey, record.userId);
+    await this.redis.expire(teamSetKey, RICH_PRESENCE_TTL_SECONDS);
+
+    this.emit('presence-updated', record);
+    this.logger.debug('Rich presence updated', { userId: record.userId, teamId: record.teamId, filePath: record.filePath });
+
+    return record;
+  }
+
+  async getPresence(userId: string): Promise<RichPresenceRecord | null> {
+    this.require(userId, 'userId');
+
+    const payload = await this.redis.get(this.userKey(userId.trim()));
+    if (!payload) {
+      return null;
+    }
+
+    return JSON.parse(payload) as RichPresenceRecord;
+  }
+
+  async listTeamPresence(teamId: string): Promise<RichPresenceRecord[]> {
+    this.require(teamId, 'teamId');
+
+    const teamUsers = await this.redis.smembers(this.teamSetKey(teamId.trim()));
+    if (teamUsers.length === 0) {
+      return [];
+    }
+
+    const records: RichPresenceRecord[] = [];
+    for (const userId of teamUsers) {
+      const record = await this.getPresence(userId);
+      if (!record) {
+        await this.redis.srem(this.teamSetKey(teamId.trim()), userId);
+        continue;
+      }
+
+      records.push(record);
+    }
+
+    records.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+    return records;
+  }
+
+  async clearPresence(userId: string): Promise<void> {
+    this.require(userId, 'userId');
+
+    const existing = await this.getPresence(userId);
+    if (!existing) {
+      return;
+    }
+
+    await this.redis.del(this.userKey(userId.trim()));
+    await this.redis.srem(this.teamSetKey(existing.teamId), userId.trim());
+    this.emit('presence-cleared', { userId: userId.trim(), teamId: existing.teamId });
+  }
+
+  private userKey(userId: string): string {
+    return `rich_presence:user:${userId}`;
+  }
+
+  private teamSetKey(teamId: string): string {
+    return `rich_presence:team:${teamId}:users`;
+  }
+
+  private require(value: string | undefined, field: string): void {
+    if (!value || value.trim().length === 0) {
+      throw new Error(`Missing required field: ${field}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Redis-backed rich presence service with 4h TTL persistence
- add APIs to upsert user presence, fetch user presence, list team presence, and clear presence
- export rich presence route/service from backend entrypoint
- add unit tests for persistence, TTL behavior, team listing, and clear flow

## Validation
- npx vitest run src/services/rich-presence/__tests__/rich-presence.test.ts

Fixes #1253