### PR TITLE
fix(helm): restore chart lintability for ranged templates

### DIFF
--- a/helm/code-server-enterprise/templates/_helpers.tpl
+++ b/helm/code-server-enterprise/templates/_helpers.tpl
@@ -60,10 +60,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "code-server-enterprise.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "code-server-enterprise.fullname" .) .Values.serviceAccount.name }}
+{{- $serviceAccount := .Values.serviceAccount | default dict -}}
+{{- if (default true $serviceAccount.create) }}
+{{- default (include "code-server-enterprise.fullname" .) $serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" $serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/helm/code-server-enterprise/templates/deployment.yaml
+++ b/helm/code-server-enterprise/templates/deployment.yaml
@@ -3,19 +3,20 @@
 # PURPOSE: Base Kubernetes Deployment template for microservices
 # PATTERN: Used by all application services
 
-{{- if .Values.services }}
-{{- range $serviceName, $serviceConfig := .Values.services }}
+{{- $root := . -}}
+{{- if $root.Values.services }}
+{{- range $serviceName, $serviceConfig := $root.Values.services }}
 {{- if $serviceConfig.enabled }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "code-server-enterprise.fullname" . }}-{{ $serviceConfig.name }}
+  name: {{ include "code-server-enterprise.fullname" $root }}-{{ $serviceConfig.name }}
   labels:
-    {{- include "code-server-enterprise.labels" . | nindent 4 }}
+    {{- include "code-server-enterprise.labels" $root | nindent 4 }}
     app.kubernetes.io/component: {{ $serviceConfig.name }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- toYaml $root.Values.annotations | nindent 4 }}
 spec:
   replicas: {{ $serviceConfig.replicas | default 1 }}
   strategy:
@@ -25,36 +26,36 @@ spec:
       maxUnavailable: 0
   selector:
     matchLabels:
-      {{- include "code-server-enterprise.selectorLabels" . | nindent 6 }}
+      {{- include "code-server-enterprise.selectorLabels" $root | nindent 6 }}
       app.kubernetes.io/component: {{ $serviceConfig.name }}
   template:
     metadata:
       labels:
-        {{- include "code-server-enterprise.selectorLabels" . | nindent 8 }}
+        {{- include "code-server-enterprise.selectorLabels" $root | nindent 8 }}
         app.kubernetes.io/component: {{ $serviceConfig.name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- toYaml .Values.annotations | nindent 8 }}
+        checksum/config: {{ include (print $root.Template.BasePath "/configmap.yaml") $root | sha256sum }}
+        {{- toYaml $root.Values.annotations | nindent 8 }}
     spec:
-      {{- with .Values.podSecurityContext }}
+      {{- with $root.Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "code-server-enterprise.serviceAccountName" . }}
+      serviceAccountName: {{ include "code-server-enterprise.serviceAccountName" $root }}
       containers:
       - name: {{ $serviceConfig.name }}
-        image: "{{ .Values.global.imageRegistry }}/{{ $serviceConfig.image }}"
-        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        image: "{{ $root.Values.global.imageRegistry }}/{{ $serviceConfig.image }}"
+        imagePullPolicy: {{ $root.Values.global.imagePullPolicy }}
         ports:
         - name: http
           containerPort: {{ $serviceConfig.port }}
           protocol: TCP
         env:
         - name: LOG_LEVEL
-          value: {{ .Values.global.logLevel | quote }}
+          value: {{ $root.Values.global.logLevel | quote }}
         - name: SERVICE_NAME
           value: {{ $serviceConfig.name | quote }}
-        {{- range $key, $value := .Values.environment }}
+        {{- range $key, $value := $root.Values.environment }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
@@ -75,7 +76,7 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 2
         resources:
-          {{- toYaml ($serviceConfig.resources | default .Values.global.resources) | nindent 12 }}
+          {{- toYaml ($serviceConfig.resources | default $root.Values.global.resources) | nindent 12 }}
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -83,7 +84,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ include "code-server-enterprise.fullname" . }}-config
+          name: {{ include "code-server-enterprise.fullname" $root }}-config
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/helm/code-server-enterprise/templates/service.yaml
+++ b/helm/code-server-enterprise/templates/service.yaml
@@ -3,19 +3,20 @@
 # PURPOSE: Kubernetes Service template for internal and external communication
 # PATTERN: ClusterIP for internal, LoadBalancer for API gateway
 
-{{- if .Values.services }}
-{{- range $serviceName, $serviceConfig := .Values.services }}
+{{- $root := . -}}
+{{- if $root.Values.services }}
+{{- range $serviceName, $serviceConfig := $root.Values.services }}
 {{- if $serviceConfig.enabled }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "code-server-enterprise.fullname" . }}-{{ $serviceConfig.name }}
+  name: {{ include "code-server-enterprise.fullname" $root }}-{{ $serviceConfig.name }}
   labels:
-    {{- include "code-server-enterprise.labels" . | nindent 4 }}
+    {{- include "code-server-enterprise.labels" $root | nindent 4 }}
     app.kubernetes.io/component: {{ $serviceConfig.name }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- toYaml $root.Values.annotations | nindent 4 }}
 spec:
   type: {{ if eq $serviceConfig.name "api" }}LoadBalancer{{ else }}ClusterIP{{ end }}
   ports:
@@ -24,7 +25,7 @@ spec:
     protocol: TCP
     name: http
   selector:
-    {{- include "code-server-enterprise.selectorLabels" . | nindent 4 }}
+    {{- include "code-server-enterprise.selectorLabels" $root | nindent 4 }}
     app.kubernetes.io/component: {{ $serviceConfig.name }}
 {{- end }}
 {{- end }}

--- a/helm/code-server-enterprise/values.yaml
+++ b/helm/code-server-enterprise/values.yaml
@@ -37,6 +37,11 @@ annotations:
   governance/policy: "GOV-002"
   governance/compliance: "required"
 
+# Service account configuration
+serviceAccount:
+  create: true
+  name: ""
+
 # Service definitions for 20 microservices
 services:
   # Core API & Gateway


### PR DESCRIPTION
## Summary
- preserve root scope when Helm templates iterate over services
- add explicit serviceAccount defaults and guard helper access when the block is absent
- restore helm lint and helm template for the merged chart

## Validation
- helm lint helm/code-server-enterprise from a clean origin/main checkout: PASS
- helm template staging helm/code-server-enterprise: PASS (1638 rendered lines)

## Why
The merged Helm chart on main dereferenced .Values from inside ange loops in service.yaml and deployment.yaml, which caused helper includes like ullname and serviceAccountName to fail with nil-pointer errors during linting. This PR passes the root context explicitly and defines the missing serviceAccount defaults so the chart is self-consistent again.

## Notes
A live staging install was not possible from this machine because there is no configured Kubernetes context, kubectl/kind were not present, and the local Docker daemon was unavailable in WSL.